### PR TITLE
handle PDC advisory API responses

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -180,6 +180,13 @@ https://access.redhat.com/articles/11258")
             for key in advisory['errata']:
                 erratum = advisory['errata'][key]
                 self.errata_type = key.upper()
+                # We cannot PUT a "PDC_"-prefixed value back to the server.
+                # The server expects "RHBA", not "PDC_RHBA". We will just
+                # remove the type internally here.
+                # (See bz 1493773 for background on why the key has the pdc_
+                # prefix here.)
+                if self.errata_type.startswith('PDC_'):
+                    self.errata_type = self.errata_type[4:]
                 break
 
             self.errata_id = erratum['id']

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -729,13 +729,18 @@ https://access.redhat.com/articles/11258")
             r = self._post(url, data=pdata)
             self._processResponse(r)
             rj = r.json()
-            self.errata_id = \
-                rj['errata'][self.errata_type.lower()]['errata_id']
+            # This might need a "pdc_" prefix, rhbz 1493773 for background
+            json_errata_type = self.errata_type.lower()
+            try:
+                rj['errata'][json_errata_type]
+            except KeyError:
+                json_errata_type = 'pdc_%s' % json_errata_type
+                rj['errata'][json_errata_type]
+            self.errata_id = rj['errata'][json_errata_type]['errata_id']
             # XXX return JSON returns full advisory name but not
             # typical advisory name - e.g. RHSA-2015:19999-01, but not
             # RHSA-2015:19999, but it's close enough
-            self.errata_name = \
-                rj['errata'][self.errata_type.lower()]['fulladvisory']
+            self.errata_name = rj['errata'][json_errata_type]['fulladvisory']
         else:
             # REFERENCE
 


### PR DESCRIPTION
The REST API returns an advisory type values prefixed with "Pdc" or "pdc_*" in some cases.

This server behavior may change in the future (rhbz#1493773).

For now, handle this gracefully so we don't crash when creating new PDC-based advisories or loading existing ones.