### PR TITLE
Include tests and license in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include errata_tool/tests *
+include LICENSE


### PR DESCRIPTION
Archive created by "make dist" does not contain tests and LICENSE file.
This makes it impossible to build rpm package using provided spec file.

MANIFEST.in providing inclusion of tests and license into source distribution
was added.