### PR TITLE
Add build even if release not specified explicitly

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -573,15 +573,18 @@ https://access.redhat.com/articles/11258")
     def addBuilds(self, buildlist, **kwargs):
         if self._new:
             raise ErrataException('Cannot add builds to unfiled erratum')
-        if 'release' not in kwargs:
+        if 'release' not in kwargs and self._release is None:
             if len(self.errata_builds) != 1:
                 raise ErrataException('Need to specify a release')
             return self.addBuildsDirect(buildlist,
                                         self.errata_builds.keys()[0],
                                         **kwargs)
+        if 'release' in kwargs:
+            release = kwargs['release']
+            del kwargs['release']
+        else:
+            release = self._release
 
-        release = kwargs['release']
-        del kwargs['release']
         return self.addBuildsDirect(buildlist, release, **kwargs)
 
     def setFileInfo(self, file_info):


### PR DESCRIPTION
Function addBuilds() gets release from parameter kwargs. If there
is not the 'release' key, it throws an exception. Errata includes
release parameter (self._release), thus it is not necessary to specify
it explicitly.

Use self._release as release if kwargs["release"] not specified.