### PR TITLE
Erratum unittests

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -626,7 +626,9 @@ https://access.redhat.com/articles/11258")
 
         if isinstance(buildlist, six.string_types):
             builds = []
-            builds.append(buildlist)
+            if len(buildlist.strip()) == 0:
+                raise IndexError
+            builds.append(buildlist.strip())
         else:
             builds = buildlist
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -629,6 +629,10 @@ https://access.redhat.com/articles/11258")
             builds.append(buildlist)
         else:
             builds = buildlist
+
+        if len(builds) == 0:
+            raise IndexError
+
         for b in builds:
             val = {}
             val['nvr'] = b

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -581,7 +581,7 @@ https://access.redhat.com/articles/11258")
             del kwargs['release']
 
         if release is None and len(self.errata_builds.keys()) == 1:
-            release = self.errata_builds.keys()[0]
+            release = list(self.errata_builds.keys())[0]
 
         if release is None:
             raise ErrataException('Need to specify a release')

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -573,15 +573,19 @@ https://access.redhat.com/articles/11258")
     def addBuilds(self, buildlist, **kwargs):
         if self._new:
             raise ErrataException('Cannot add builds to unfiled erratum')
-        if 'release' not in kwargs:
-            if len(self.errata_builds) != 1:
-                raise ErrataException('Need to specify a release')
-            return self.addBuildsDirect(buildlist,
-                                        self.errata_builds.keys()[0],
-                                        **kwargs)
 
-        release = kwargs['release']
-        del kwargs['release']
+        release = None
+
+        if 'release' in kwargs:
+            release = kwargs['release']
+            del kwargs['release']
+
+        if release is None and len(self.errata_builds.keys()) == 1:
+            release = self.errata_builds.keys()[0]
+
+        if release is None:
+            raise ErrataException('Need to specify a release')
+
         return self.addBuildsDirect(buildlist, release, **kwargs)
 
     def setFileInfo(self, file_info):

--- a/errata_tool/tests/test_add_builds.py
+++ b/errata_tool/tests/test_add_builds.py
@@ -1,4 +1,6 @@
 import requests
+import pytest
+from errata_tool import ErrataException
 
 
 class TestAddBuilds(object):
@@ -16,3 +18,50 @@ class TestAddBuilds(object):
             "build": "ceph-10.2.3-17.el7cp",
         }
         assert mock_post.kwargs['json'] == [expected]
+
+    def test_builds_no_release(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.addBuilds(['ceph-10.2.3-17.el7cp'])
+        expected = {
+            "product_version": "RHEL-7-CEPH-2",
+            "build": "ceph-10.2.3-17.el7cp",
+        }
+        assert mock_post.kwargs['json'] == [expected]
+
+    def test_builds_empty_no_release(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.errata_builds = {}
+        with pytest.raises(ErrataException,
+                           message='Need to specify a release'):
+            advisory.addBuilds(['ceph-10.2.3-17.el7cp'])
+
+    def test_builds_release_none(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.addBuilds(['ceph-10.2.3-17.el7cp'], release=None)
+        expected = {
+            "product_version": "RHEL-7-CEPH-2",
+            "build": "ceph-10.2.3-17.el7cp",
+        }
+        assert mock_post.kwargs['json'] == [expected]
+
+    def test_builds_new_advisory(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory._new = True
+        with pytest.raises(ErrataException,
+                           message='Cannot add builds to unfiled erratum'):
+            advisory.addBuilds(['ceph-10.2.3-17.el7cp'])
+
+    def test_2_builds_data(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.addBuilds(['ceph-10.2.3-17.el7cp', 'foo-1.2.3-11.el7cp'])
+        expected = [
+            {
+                "product_version": "RHEL-7-CEPH-2",
+                "build": "ceph-10.2.3-17.el7cp",
+            },
+            {
+                "product_version": "RHEL-7-CEPH-2",
+                "build": "foo-1.2.3-11.el7cp",
+            }
+        ]
+        assert mock_post.kwargs['json'] == expected

--- a/errata_tool/tests/test_remove_builds.py
+++ b/errata_tool/tests/test_remove_builds.py
@@ -36,6 +36,18 @@ class TestRemoveBuilds(object):
             advisory.removeBuilds(None)
         assert advisory._buildschanged is False
 
+    def test_builds_empty_string(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds('')
+        assert advisory._buildschanged is False
+
+    def test_builds_whitespace_string(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds(' ')
+        assert advisory._buildschanged is False
+
     def test_builds_empty_set(self, monkeypatch, mock_post, advisory):
         monkeypatch.setattr(requests, 'post', mock_post)
         with pytest.raises(IndexError):

--- a/errata_tool/tests/test_remove_builds.py
+++ b/errata_tool/tests/test_remove_builds.py
@@ -1,0 +1,55 @@
+import requests
+import pytest
+
+
+class TestRemoveBuilds(object):
+
+    def test_builds_url(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.removeBuilds(['ceph-10.2.3-17.el7cp'])
+        assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/26175/remove_build'  # NOQA: E501
+
+    def test_builds_flag_set(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.removeBuilds(['ceph-10.2.3-17.el7cp'])
+        assert advisory._buildschanged is True
+
+    def test_builds_data(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.removeBuilds(['ceph-10.2.3-17.el7cp'])
+        expected = {
+            "nvr": "ceph-10.2.3-17.el7cp",
+        }
+        assert mock_post.kwargs['data'] == expected
+
+    def test_builds_name(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.removeBuilds('ceph-10.2.3-17.el7cp')
+        expected = {
+            "nvr": "ceph-10.2.3-17.el7cp",
+        }
+        assert mock_post.kwargs['data'] == expected
+
+    def test_builds_none(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds(None)
+        assert advisory._buildschanged is False
+
+    def test_builds_empty_set(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds(set())
+        assert advisory._buildschanged is False
+
+    def test_builds_empty_list(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds([])
+        assert advisory._buildschanged is False
+
+    def test_builds_empty_tuple(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        with pytest.raises(IndexError):
+            advisory.removeBuilds(())
+        assert advisory._buildschanged is False


### PR DESCRIPTION
Expand coverage of unittests for erratum.py

addBuilds() and removeBuilds()

a couple of guard and edge case handling and more test cases to cover general good case scenarios