### PR TITLE
README: setState() requires commit()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,7 @@ Changing state:
     e = Erratum(errata_id=24075)
 
     e.setState('QE')
+    e.commit()
 
 Changing docs reviewer:
 


### PR DESCRIPTION
`setState()` only changes the internal representation of the state in the local Erratum class. It does not change the advisory state on the server.

We have to call `commit()` to send this change to the server.