### PR TITLE
new-fixture.sh: follow ".body" filename convention

### DIFF
--- a/new-fixture.sh
+++ b/new-fixture.sh
@@ -21,6 +21,9 @@ DIRNAME=$(dirname $FIXTURE)
 
 cd errata_tool/tests/fixtures/
 mkdir -p $DIRNAME
+if [ -d $FIXTURE ]; then
+  FIXTURE=$FIXTURE.body
+fi
 curl -g --negotiate -u : -q $URL > $FIXTURE
 
 git add $FIXTURE


### PR DESCRIPTION
This change allows new-fixture.sh to integrate more with the change from fec26a52e1c08434e6e27f9538f0c4d4476ca7a8, "tests: permit API fixtures as directories".

When downloading a new fixture file, if we already have a directory on disk for this test fixture, write to the corresponding .body file instead.