### PR TITLE
Erratum: add missing_prod_listings attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,8 +218,9 @@ Reloading the all specific builds that lack product listings:
 
     e = Erratum(errata_id=24075)
 
-    result = e.reloadBuilds(no_rpm_listing_only=True)
-    # result is a dict for this job tracker
+    if e.missing_product_listings:  # a (possibly-empty) list of build NVRs
+        result = e.reloadBuilds(no_rpm_listing_only=True)
+        # result is a dict for this job tracker
 
 Determining if an advisory has RPMs or containers:
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -414,11 +414,11 @@ https://access.redhat.com/articles/11258")
         for product_version in product_versions:
             builds = []
             for pv_builds in product_versions[product_version]:
-                for b in pv_builds:
-                    builds.append(b)
+                for nvr in pv_builds:
+                    builds.append(nvr)
                     if have_all_sigs and check_signatures:
 
-                        if not self._check_signature_for_build(b):
+                        if not self._check_signature_for_build(nvr):
                             self.addFlags('needs_sigs')
                             have_all_sigs = False
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -61,6 +61,7 @@ class Erratum(ErrataConnector):
         self.errata_bugs = []
         self.errata_builds = {}
         self.current_flags = []
+        self.missing_prod_listings = []
 
     def update(self, **kwargs):
         if 'errata_type' in kwargs:
@@ -414,8 +415,10 @@ https://access.redhat.com/articles/11258")
         for product_version in product_versions:
             builds = []
             for pv_builds in product_versions[product_version]:
-                for nvr in pv_builds:
+                for nvr, mappings in six.iteritems(pv_builds):
                     builds.append(nvr)
+                    if not mappings:
+                        self.missing_prod_listings.append(nvr)
                     if have_all_sigs and check_signatures:
 
                         if not self._check_signature_for_build(nvr):

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -72,6 +72,10 @@ class TestAdvisory(object):
         expected = {'RHEL-7-CEPH-2': ['ceph-10.2.5-37.el7cp']}
         assert advisory.errata_builds == expected
 
+    def test_missing_prod_listings(self, advisory):
+        # (note, all builds have product listings for this advisory)
+        assert advisory.missing_prod_listings == []
+
     def test_current_flags(self, advisory):
         assert advisory.current_flags == []
 


### PR DESCRIPTION
This pull request adds `.missing_prod_listings`, a (possibly-empty) list of builds for which the Errata Tool could find no prod-listings.

This attribute helps users to know if they should reload the build list (as in the README), or possibly open a ticket with RCM.