### PR TITLE
connector: raise with specific HTTP 500 error message

### DIFF
--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -247,9 +247,12 @@ class ErrataConnector(object):
             raise ErrataException('Pigeon crap. Did it forget to run kinit?')
 
         if r.status_code in [500]:
-            err_msg += "Broke errata tool!"
-            print(r.json())
-            raise ErrataException(err_msg)
+            json = r.json()
+            # If we have a specific "error" string from the ET, raise that:
+            if 'error' in json:
+                raise ErrataException(json['error'])
+            # Otherwise, fall back to just raising whatever data we got back.
+            raise ErrataException(json)
 
         if r.status_code in [404]:
             err_msg += 'Bug in your code - wrong method for this api? '


### PR DESCRIPTION
If we get an HTTP 500 response from the Errata Tool, we probably have a useful error message in the HTTP body.

As one example: when I try to create a new advisory for a new release before RCM has created the new release, the ET returns an HTTP 500 with the following JSON:

```json
  {"error": "ERROR: Couldn't find Release without an ID"}
```

Instead of printing the json to STDOUT, return the data in the exception itself.

This allows callers to discover the specific error message. Callers can print human-readable explanations about what went wrong and what steps to take next (for example, "file an RCM ticket to create this new release").