### PR TITLE
make: simplify "dist" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ clean:
 
 dist:
 	find errata_tool -name __pycache__ -o -name '*.pyc' | xargs rm -rf \
-	  && python setup.py sdist \
-	  && mv dist/errata-tool-$(VERSION).tar.gz .
+	  && python setup.py sdist --dist-dir .
 
 srpm: dist
 	fedpkg --dist epel7 srpm


### PR DESCRIPTION
Use --dist-dir to write the tarball directly to the root of the tree, rather than moving it in a separate step.

Props to Lukas Holecek <lholecek@redhat.com> for this tip.