### PR TITLE
Adding basic batch_id information to erratum

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -62,6 +62,7 @@ class Erratum(ErrataConnector):
         self.errata_builds = {}
         self.current_flags = []
         self.missing_prod_listings = []
+        self.batch_id = None
 
     def update(self, **kwargs):
         if 'errata_type' in kwargs:
@@ -299,6 +300,7 @@ https://access.redhat.com/articles/11258")
 
             check_signatures = self.errata_state != 'NEW_FILES'
             self._get_build_list(check_signatures)
+            self.batch_id = erratum.get('batch_id')
 
             return
 

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -81,3 +81,6 @@ class TestAdvisory(object):
 
     def test_content_types(self, advisory):
         assert advisory.content_types == ['rpm']
+
+    def test_batch_id(self, advisory):
+        assert advisory.batch_id is None


### PR DESCRIPTION
Adding a erratum.batch_id property, this will give the user the batch_id
number if the advisory is part of one.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>