### PR TITLE
doc: mock C-based libraries on rtd.org

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,21 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../'))
 
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if on_rtd:
+    # Mock C-based libraries, as suggested in
+    # http://read-the-docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+    from unittest.mock import MagicMock
+
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+            return MagicMock()
+
+    MOCK_MODULES = ['requests_kerberos', 'kerberos', 'jsonpath_rw']
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+
 import errata_tool  # NOQA E402, F401
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
readthedocs.org does not support installing C-based libraries, so we cannot `import errata_tool` unless we mock these libraries in that environment.

MagicMock is in stdlib as of Python 3.3, so we require Python 3.3 in the readthedocs.org build environment.