### PR TITLE
rpm: change obsolete python_version macro to python2_version

### DIFF
--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -75,7 +75,7 @@ cp -a . %{py3dir}
 
 %check
 export PYTHONPATH=$(pwd)
-py.test-%{python_version} -v errata_tool/tests
+py.test-%{python2_version} -v errata_tool/tests
 
 %if 0%{?with_python3}
 pushd %{py3dir}


### PR DESCRIPTION
`python_version` is not available on Rawhide (Fedora 29). Use `python2_version` instead.