### PR TITLE
erratum: add .text_only_cpe attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,7 @@ Checking whether an advisory is text-only:
 
     if e.text_only:
         # it's text-only
+        # If it's an RHSA, you may want to get/set e.text_only_cpe here.
     else:
         # it's not text-only
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -43,6 +43,7 @@ class Erratum(ErrataConnector):
         # primarily for debugging/printing by user apps
         self.errata_type = None
         self.text_only = False
+        self.text_only_cpe = None
         self.publish_date_override = None
         self.creation_date = None
         self.ship_date = None           # Set if SHIPPED_LIVE
@@ -74,6 +75,9 @@ class Erratum(ErrataConnector):
             self._update = True
         if 'text_only' in kwargs:
             self.text_only = kwargs['text_only']
+            self._update = True
+        if 'text_only_cpe' in kwargs:
+            self.text_only_cpe = kwargs['text_only_cpe']
             self._update = True
         if 'date' in kwargs:
             try:
@@ -277,6 +281,7 @@ https://access.redhat.com/articles/11258")
             self.text_only = erratum['text_only']
             self.synopsis = erratum['synopsis']
             content = advisory['content']['content']
+            self.text_only_cpe = content['text_only_cpe']
             self.topic = content['topic']
             self.description = content['description']
             self.solution = content['solution']
@@ -787,6 +792,9 @@ https://access.redhat.com/articles/11258")
 
         # POST/PUT a 1 or 0 value for this text_only boolean
         pdata['advisory[text_only]'] = int(self.text_only)
+
+        if self.text_only_cpe:
+            pdata['advisory[text_only_cpe]'] = self.text_only_cpe
 
         if self.publish_date_override:
             pdata['advisory[publish_date_override]'] = \

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -276,12 +276,13 @@ https://access.redhat.com/articles/11258")
             # Grab mutable errata content
             self.text_only = erratum['text_only']
             self.synopsis = erratum['synopsis']
-            self.topic = advisory['content']['content']['topic']
-            self.description = advisory['content']['content']['description']
-            self.solution = advisory['content']['content']['solution']
+            content = advisory['content']['content']
+            self.topic = content['topic']
+            self.description = content['description']
+            self.solution = content['solution']
             self.errata_bugs = [int(b['bug']['id']) for b
                                 in advisory['bugs']['bugs']]
-            self.cve_names = advisory['content']['content']['cve']
+            self.cve_names = content['cve']
             if self.cve_names == '':
                 self.cve_names = None
             self._original_bugs = list(self.errata_bugs)

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -55,6 +55,9 @@ class TestAdvisory(object):
     def test_text_only(self, advisory):
         assert advisory.text_only is False
 
+    def test_text_only_cpe(self, advisory):
+        assert advisory.text_only_cpe is None
+
     def test_publish_date_override(self, advisory):
         assert advisory.publish_date_override is None
 


### PR DESCRIPTION
Support reading or setting the CPE text for text-only advisories.