### PR TITLE
cli: require subparsers in python 3

### DIFF
--- a/errata_tool/cli/advisory.py
+++ b/errata_tool/cli/advisory.py
@@ -6,7 +6,8 @@ def add_parser(subparsers):
     group = subparsers.add_parser('advisory', help='Get or create an advisory')
 
     # advisory-level subcommands:
-    sub = group.add_subparsers()
+    sub = group.add_subparsers(dest='advisory_subcommand')
+    sub.required = True
 
     # "get"
     get_parser = sub.add_parser('get')

--- a/errata_tool/cli/build.py
+++ b/errata_tool/cli/build.py
@@ -8,7 +8,8 @@ def add_parser(subparsers):
     group = subparsers.add_parser('build', help='Build NVR information')
 
     # build-level sub-commands:
-    sub = group.add_subparsers()
+    sub = group.add_subparsers(dest='build_subcommand')
+    sub.required = True
 
     # "get"
     get_parser = sub.add_parser('get')

--- a/errata_tool/cli/main.py
+++ b/errata_tool/cli/main.py
@@ -13,7 +13,8 @@ def main():
                         help="show what would happen, but don't do it")
 
     # top-level subcommands:
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest='subcommand')
+    subparsers.required = True
 
     # add arguments for each subcommand:
     errata_tool.cli.advisory.add_parser(subparsers)

--- a/errata_tool/cli/product.py
+++ b/errata_tool/cli/product.py
@@ -6,7 +6,8 @@ def add_parser(subparsers):
     group = subparsers.add_parser('product', help='Get a product')
 
     # product-level subcommands:
-    sub = group.add_subparsers()
+    sub = group.add_subparsers(dest='product_subcommand')
+    sub.required = True
 
     # "get"
     get_parser = sub.add_parser('get')

--- a/errata_tool/cli/release.py
+++ b/errata_tool/cli/release.py
@@ -11,7 +11,8 @@ def add_parser(subparsers):
                                   help='Get or create a release (RCM)')
 
     # release-level subcommands:
-    sub = group.add_subparsers()
+    sub = group.add_subparsers(dest='release_subcommand')
+    sub.required = True
 
     # "get"
     get_parser = sub.add_parser('get', help='get a release')


### PR DESCRIPTION
When we call `add_subparsers()` on Python 2, Argparse will always require that sub-command.

On Python 3, Argparse's does not require the sub-command unless we tell it to do so. This would lead to a crash later on when we called `args.func()` because that attribute was not set.