### PR TITLE
Add support for product Versions from release

### DIFF
--- a/errata_tool/release.py
+++ b/errata_tool/release.py
@@ -54,6 +54,20 @@ class Release(ErrataConnector):
         # For displaying in scripts/logs:
         self.edit_url = self._url + '/release/edit/%d' % self.id
 
+    def get_product_versions(self):
+        url = self._url + '/api/v1/releases' % self.id
+        result = self._get(url)
+        if len(result['data']) < 1:
+            raise NoReleaseFoundError()
+        if len(result['data']) > 1:
+            # it's possible to accidentally have identically named releases,
+            # see engineering RT 461783
+            raise MultipleReleasesFoundError()
+        for d in self.data:
+            if d['id'] == self.id:
+                return d['relationships']['product_versions']
+        return None
+
     def advisories(self):
         """
         Find all advisories for this release.

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -132,6 +132,15 @@ def release(monkeypatch, mock_get):
 
 
 @pytest.fixture
+def release_id(monkeypatch, mock_get):
+    monkeypatch.delattr('requests.sessions.Session.request')
+    monkeypatch.setattr(ErrataConnector, '_auth', None)
+    monkeypatch.setattr(ErrataConnector, '_username', 'test')
+    monkeypatch.setattr(requests, 'get', mock_get)
+    rel = Release(name='rhceph-3.1')
+    return rel.id
+
+@pytest.fixture
 def build(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)

--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -39,6 +39,17 @@ class TestGet(object):
         assert release.edit_url == expected
 
 
+class TestProductVersions(object):
+    def test_product_verions(self, release, release_id, monkeypatch, mock_get):
+        monkeypatch.setattr(requests, 'get', mock_get)
+        release.id = release_id
+        expected_url = 'https://errata.devel.redhat.com/releases.json'
+        assert mock_get.response.url == expected_url
+        expected_product_versions = [{"id": 783, "name": "RHEL-7-CEPH-3.1"}]
+        result = release.get_product_versions()
+        assert result == expected_product_versions
+
+
 class TestAdvisories(object):
     def test_advisories(self, release, monkeypatch, mock_get):
         monkeypatch.setattr(requests, 'get', mock_get)


### PR DESCRIPTION
Signed-off-by: Petr Stone Hracek <phracek@redhat.com>
This Pull request adds support for getting productversions based on releases.