### PR TITLE
setup.py: rm unused test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,6 @@ setup(
     tests_require=[
         'pytest',
         'pytest-flake8',
-        'httpretty',
     ],
     cmdclass={'test': PyTest, 'bump': BumpCommand, 'release': ReleaseCommand},
 )


### PR DESCRIPTION
This was a leftover from the initial import to GitHub. As it turned out, we never used httpretty for testing.