### PR TITLE
connector: better debugging for HTTP 500 GET errors

### DIFF
--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -169,9 +169,6 @@ class ErrataConnector(object):
             elif ret_data.status_code in [403]:
                 raise ErrataException(
                     'You need Errata access for this operation!')
-            elif ret_data.status_code in [500]:
-                raise LookupError('No matching errata')
-
             else:
                 print("Result not handled: " + str(ret_data))
                 print("While fetching: " + url)

--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -170,7 +170,7 @@ class ErrataConnector(object):
                 raise ErrataException(
                     'You need Errata access for this operation!')
             else:
-                print("Result not handled: " + str(ret_data))
+                print("Result not handled: " + str(ret_data.text))
                 print("While fetching: " + url)
                 raise ErrataException(str(ret_data))
 


### PR DESCRIPTION
Prior to this change, if we GET a URL and received a HTTP 500 response, we would raise a simple LookupError with no further information about what went wrong.

Update the error handling logic in `_get()` so that we will raise `ErrataException` instead. This will give us a lot more information about the URL we were trying to access and the response back from the server.