### PR TITLE
user: use login_name for __str__

### DIFF
--- a/errata_tool/user.py
+++ b/errata_tool/user.py
@@ -20,4 +20,4 @@ class User(ErrataConnector):
         return 'User(%s)' % self.id
 
     def __str__(self):
-        return self.name
+        return self.login_name


### PR DESCRIPTION
The Errata Tool does not return a "name" value in the user REST API.
It's "login_name" instead.