### PR TITLE
erratum: update comments about missing manager

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -271,10 +271,11 @@ https://access.redhat.com/articles/11258")
             self.product_id = advisory_old['product']['id']
             self.release_id = advisory_old['release']['id']
 
-            # XXX Errata tool doesn't report package owner or manager?
             self.package_owner_email = advisory_old['people']['reporter']
             self.qe_email = advisory_old['people']['assigned_to']
             self.qe_group = advisory_old['people']['qe_group']
+            # XXX Errata tool doesn't report manager?
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1664884
             # self.manager_email = ???
 
             # Grab mutable errata content

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -48,7 +48,7 @@ class TestAdvisory(object):
     def test_manager_email_is_none(self, advisory):
         # NOTE: the ET does not give this information when querying a
         # pre-existing advisory. We can only update it with POST/PUT, but we
-        # cannot GET it.
+        # cannot GET it. https://bugzilla.redhat.com/show_bug.cgi?id=1664884
         #  assert advisory.manager_email == 'gmeno@redhat.com'
         assert advisory.manager_email is None
 


### PR DESCRIPTION
This bug tracks adding the manager email address to the Errata Tool REST API: https://bugzilla.redhat.com/show_bug.cgi?id=1664884

Link to it in the comments where we would have assigned `.manager_email`.