### PR TITLE
erratum: fix .package_owner_email assignment and add .reporter attribute

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -276,6 +276,7 @@ https://access.redhat.com/articles/11258")
             self.release_id = advisory_old['release']['id']
 
             self.package_owner_email = advisory_old['people']['package_owner']
+            self.reporter = advisory_old['people']['reporter']
             self.qe_email = advisory_old['people']['assigned_to']
             self.qe_group = advisory_old['people']['qe_group']
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -275,7 +275,7 @@ https://access.redhat.com/articles/11258")
             self.product_id = advisory_old['product']['id']
             self.release_id = advisory_old['release']['id']
 
-            self.package_owner_email = advisory_old['people']['reporter']
+            self.package_owner_email = advisory_old['people']['package_owner']
             self.qe_email = advisory_old['people']['assigned_to']
             self.qe_group = advisory_old['people']['qe_group']
 
@@ -1060,7 +1060,7 @@ https://access.redhat.com/articles/11258")
             s = "\n  CVEs:        " + str(self.cve_names) + s
 
         return self.errata_name + ": " + self.synopsis + \
-            "\n  reporter: " + self.package_owner_email + \
+            "\n  package owner: " + self.package_owner_email + \
             "  qe: " + self.qe_email + \
             " qe_group: " + self.qe_group + \
             "\n  url:   " + \

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -45,6 +45,9 @@ class TestAdvisory(object):
     def test_owner_email(self, advisory):
         assert advisory.package_owner_email == 'kdreyer@redhat.com'
 
+    def test_reporter(self, advisory):
+        assert advisory.reporter == 'kdreyer@redhat.com'
+
     def test_manager_email_is_none(self, advisory):
         # NOTE: the ET does not give this information when querying a
         # pre-existing advisory. We can only update it with POST/PUT, but we


### PR DESCRIPTION
Prior to this change, when querying an existing advisory, the `.package_owner_email` was actually set to the advisory's "reporter" value.

In an Errata Tool advisory, a Package Owner and a Reporter can be two different people.

Assign the `.package_owner_email` attribute to the `package_owner` value we get back from the Errata Tool's JSON.

Expose the advisory's "reporter" field in a new `.reporter` attribute.