### PR TITLE
connector: use persistent requests.Session

### DIFF
--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -14,6 +14,7 @@ class ErrataConnector(object):
     _url = "https://errata.devel.redhat.com"
     _auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
     _username = None
+    session = requests.Session()
     ssl_verify = True  # Shared
     debug = False
 
@@ -119,19 +120,18 @@ class ErrataConnector(object):
         url = self.canonical_url(u)
         start = time.time()
         ret = None
+        self.session.verify = self.ssl_verify
         if kwargs is not None:
             if 'data' in kwargs:
-                ret = requests.post(url,
-                                    auth=self._auth,
-                                    data=kwargs['data'],
-                                    verify=self.ssl_verify)
+                ret = self.session.post(url,
+                                        auth=self._auth,
+                                        data=kwargs['data'])
             elif 'json' in kwargs:
-                ret = requests.post(url,
-                                    auth=self._auth,
-                                    json=kwargs['json'],
-                                    verify=self.ssl_verify)
+                ret = self.session.post(url,
+                                        auth=self._auth,
+                                        json=kwargs['json'])
         if ret is None:
-            ret = requests.post(url, auth=self._auth, verify=self.ssl_verify)
+            ret = self.session.post(url, auth=self._auth)
 
         self._record('POST', url, time.time() - start)
         return ret
@@ -144,19 +144,16 @@ class ErrataConnector(object):
         start = time.time()
         if kwargs is not None:
             if 'data' in kwargs:
-                ret_data = requests.get(url,
-                                        auth=self._auth,
-                                        data=kwargs['data'],
-                                        verify=self.ssl_verify)
+                ret_data = self.session.get(url,
+                                            auth=self._auth,
+                                            data=kwargs['data'])
             elif 'json' in kwargs:
-                ret_data = requests.get(url,
-                                        auth=self._auth,
-                                        json=kwargs['json'],
-                                        verify=self.ssl_verify)
+                ret_data = self.session.get(url,
+                                            auth=self._auth,
+                                            json=kwargs['json'])
 
         if ret_data is None:
-            ret_data = requests.get(url, auth=self._auth,
-                                    verify=self.ssl_verify)
+            ret_data = self.session.get(url, auth=self._auth)
 
         self._record('GET', url, time.time() - start)
 
@@ -183,18 +180,16 @@ class ErrataConnector(object):
         ret = None
         if kwargs is not None:
             if 'data' in kwargs:
-                ret = requests.put(url,
-                                   auth=self._auth,
-                                   data=kwargs['data'],
-                                   verify=self.ssl_verify)
+                ret = self.session.put(url,
+                                       auth=self._auth,
+                                       data=kwargs['data'])
             elif 'json' in kwargs:
-                ret = requests.put(url,
-                                   auth=self._auth,
-                                   json=kwargs['json'],
-                                   verify=self.ssl_verify)
+                ret = self.session.put(url,
+                                       auth=self._auth,
+                                       json=kwargs['json'])
 
         if ret is None:
-            ret = requests.put(url, auth=self._auth, verify=self.ssl_verify)
+            ret = self.session.put(url, auth=self._auth)
         self._record('PUT', url, time.time() - start)
         return ret
 

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -6,7 +6,6 @@ from errata_tool.products import ProductList
 from errata_tool.product import Product
 from errata_tool.product_version import ProductVersion
 from errata_tool.release import Release
-import requests
 import pytest
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -78,63 +77,56 @@ def mock_put():
 
 @pytest.fixture
 def advisory(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=33840)
 
 
 @pytest.fixture
 def rhsa(monkeypatch, mock_get):
     """ Like the advisory() fixture above, but an RHSA. """
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=36762)
 
 
 @pytest.fixture
 def productlist(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return ProductList()
 
 
 @pytest.fixture
 def product(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Product('RHCEPH')
 
 
 @pytest.fixture
 def product_version(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return ProductVersion('RHEL-7-RHCEPH-3.1')
 
 
 @pytest.fixture
 def release(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Release(name='rhceph-3.1')
 
 
 @pytest.fixture
 def build(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(ErrataConnector, '_username', 'test')
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Build('ceph-12.2.5-42.el7cp')

--- a/errata_tool/tests/test_add_builds.py
+++ b/errata_tool/tests/test_add_builds.py
@@ -1,17 +1,17 @@
-import requests
 import pytest
+from errata_tool import ErrataConnector
 from errata_tool import ErrataException
 
 
 class TestAddBuilds(object):
 
     def test_add_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release='RHEL-7-RHCEPH-3.1')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/add_builds'  # NOQA: E501
 
     def test_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release='RHEL-7-RHCEPH-3.1')
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -20,7 +20,7 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_no_release(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'])
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -29,14 +29,14 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_empty_no_release(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.errata_builds = {}
         with pytest.raises(ErrataException,
                            message='Need to specify a release'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_builds_release_none(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release=None)
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -45,14 +45,14 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_new_advisory(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory._new = True
         with pytest.raises(ErrataException,
                            message='Cannot add builds to unfiled erratum'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_2_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp', 'foo-1.2.3-11.el7cp'])
         expected = [
             {

--- a/errata_tool/tests/test_add_cc.py
+++ b/errata_tool/tests/test_add_cc.py
@@ -1,15 +1,15 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestAddCC(object):
 
     def test_add_cc_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addCC('kdreyer@redhat.com')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/carbon_copies/add_to_cc_list'  # NOQA: E501
 
     def test_add_cc_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addCC('kdreyer@redhat.com')
         expected = {'id': 33840, 'email': 'kdreyer@redhat.com'}
         assert mock_post.kwargs['data'] == expected

--- a/errata_tool/tests/test_change_docs_reviewer.py
+++ b/errata_tool/tests/test_change_docs_reviewer.py
@@ -1,14 +1,14 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestChangeDocsReviewer(object):
 
     def test_change_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.changeDocsReviewer('kdreyer@redhat.com')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/change_docs_reviewer'  # NOQA: E501
 
     def test_change_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.changeDocsReviewer('kdreyer@redhat.com')
         assert mock_post.kwargs['data'] == {'login_name': 'kdreyer@redhat.com'}

--- a/errata_tool/tests/test_external_tests.py
+++ b/errata_tool/tests/test_external_tests.py
@@ -1,14 +1,14 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestExternalTests(object):
 
     def test_external_tests_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.externalTests(test_type='rpmdiff')
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/external_tests/?filter[active]=true&filter[errata_id]=33840&filter[test_type]=rpmdiff'  # NOQA: E501
 
     def test_external_tests_data(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         rpmdiff = advisory.externalTests(test_type='rpmdiff')
         assert len(rpmdiff) == 35

--- a/errata_tool/tests/test_metadata_cdn_repos.py
+++ b/errata_tool/tests/test_metadata_cdn_repos.py
@@ -1,22 +1,22 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestMetadataCdnRepos(object):
 
     def test_get_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.metadataCdnRepos()
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/metadata_cdn_repos'  # NOQA: E501
 
     def test_enable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.metadataCdnRepos(enable=[repo])
         expected = [{'enabled': True, 'repo': repo}]
         assert mock_put.kwargs['json'] == expected
 
     def test_disable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.metadataCdnRepos(disable=[repo])
         expected = [{'enabled': False, 'repo': repo}]

--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -1,5 +1,4 @@
 from datetime import date
-import requests
 from errata_tool.release import Release
 from errata_tool.connector import ErrataConnector
 
@@ -45,7 +44,7 @@ class TestGet(object):
 
 class TestAdvisories(object):
     def test_advisories(self, release, monkeypatch, mock_get):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         result = release.advisories()
         # Validate URL
         expected_url = 'https://errata.devel.redhat.com/release/860/advisories.json'  # NOQA: E501
@@ -89,16 +88,16 @@ class TestCreate(object):
     )
 
     def test_create_url(self, monkeypatch, mock_get, mock_post):
-        monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         monkeypatch.setattr(ErrataConnector, '_username', 'test')
         Release.create(**self.create_kwargs)
         expected = 'https://errata.devel.redhat.com/release/create'
         assert mock_post.response.url == expected
 
     def test_create_data(self, monkeypatch, mock_get, mock_post):
-        monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         monkeypatch.setattr(ErrataConnector, '_username', 'test')
         Release.create(**self.create_kwargs)
         today = date.today()

--- a/errata_tool/tests/test_reload_builds.py
+++ b/errata_tool/tests/test_reload_builds.py
@@ -1,15 +1,15 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestReloadBuilds(object):
 
     def test_reload_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.reloadBuilds()
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/reload_builds'  # NOQA: E501
 
     def test_reload_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.reloadBuilds()
         expected = {'no_rpm_listing_only': 0, 'no_current_files_only': 0}
         assert mock_post.kwargs['data'] == expected

--- a/errata_tool/tests/test_remove_builds.py
+++ b/errata_tool/tests/test_remove_builds.py
@@ -1,21 +1,21 @@
-import requests
+from errata_tool import ErrataConnector
 import pytest
 
 
 class TestRemoveBuilds(object):
 
     def test_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/remove_build'  # NOQA: E501
 
     def test_builds_flag_set(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         assert advisory._buildschanged is True
 
     def test_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         expected = {
             "nvr": "ceph-12.2.5-42.el7cp",
@@ -23,7 +23,7 @@ class TestRemoveBuilds(object):
         assert mock_post.kwargs['data'] == expected
 
     def test_builds_name(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds('ceph-12.2.5-42.el7cp')
         expected = {
             "nvr": "ceph-12.2.5-42.el7cp",
@@ -31,37 +31,37 @@ class TestRemoveBuilds(object):
         assert mock_post.kwargs['data'] == expected
 
     def test_builds_none(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(None)
         assert advisory._buildschanged is False
 
     def test_builds_empty_string(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds('')
         assert advisory._buildschanged is False
 
     def test_builds_whitespace_string(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(' ')
         assert advisory._buildschanged is False
 
     def test_builds_empty_set(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(set())
         assert advisory._buildschanged is False
 
     def test_builds_empty_list(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds([])
         assert advisory._buildschanged is False
 
     def test_builds_empty_tuple(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(())
         assert advisory._buildschanged is False

--- a/errata_tool/tests/test_rhsa_synopsis.py
+++ b/errata_tool/tests/test_rhsa_synopsis.py
@@ -1,4 +1,4 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestRhsaSynopsis(object):
@@ -7,8 +7,8 @@ class TestRhsaSynopsis(object):
         """
         Verify that we do not include the "Moderate: " prefix in our PUT data.
         """
-        monkeypatch.setattr(requests, 'post', mock_post)
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         # Any typical advisory update would toggle this internal "_update"
         # attribute. Simulate that here:
         rhsa._update = True

--- a/errata_tool/tests/test_text_only_repos.py
+++ b/errata_tool/tests/test_text_only_repos.py
@@ -1,22 +1,22 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestTextOnlyRepos(object):
 
     def test_get_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.textOnlyRepos()
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/text_only_repos'  # NOQA: E501
 
     def test_enable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.textOnlyRepos(enable=[repo])
         expected = [{'enabled': True, 'repo': repo}]
         assert mock_put.kwargs['json'] == expected
 
     def test_disable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.textOnlyRepos(disable=[repo])
         expected = [{'enabled': False, 'repo': repo}]


### PR DESCRIPTION
Instead of setting up and tearing down new request sessions for every HTTP request, use a persistent session object in the `ErrataConnector` class.