### PR TITLE
pytest deprected warning about message

### DIFF
--- a/errata_tool/tests/test_add_builds.py
+++ b/errata_tool/tests/test_add_builds.py
@@ -32,7 +32,7 @@ class TestAddBuilds(object):
         monkeypatch.setattr(requests, 'post', mock_post)
         advisory.errata_builds = {}
         with pytest.raises(ErrataException,
-                           message='Need to specify a release'):
+                           match=r'Need to specify a release'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_builds_release_none(self, monkeypatch, mock_post, advisory):
@@ -48,7 +48,7 @@ class TestAddBuilds(object):
         monkeypatch.setattr(requests, 'post', mock_post)
         advisory._new = True
         with pytest.raises(ErrataException,
-                           message='Cannot add builds to unfiled erratum'):
+                           match=r'Cannot add builds to unfiled erratum'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_2_builds_data(self, monkeypatch, mock_post, advisory):


### PR DESCRIPTION
pytest deprecated the message parameter
the replacement is to use match

Resolves: https://github.com/red-hat-storage/errata-tool/issues/163