### PR TITLE
README: rm additional PDC reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,10 +182,8 @@ Adding builds:
 
     e = Erratum(errata_id=24075)
 
-    # For non-PDC advisories, the "release" kwarg is the Errata Tools's
-    # "product version", in composedb, for example "RHEL-7-CEPH-2".
-    # For PDC advisories, the "release" kwarg is the PDC identifier,
-    # for example "rhceph-2.4@rhel-7".
+    # The "release" kwarg is the Errata Tools's "product version" in
+    # composedb, for example "RHEL-7-CEPH-2".
     e.addBuilds(['ceph-10.2.3-17.el7cp'], release='RHEL-7-CEPH-2')
 
 Adding container builds:


### PR DESCRIPTION
Since we've dropped PDC support, remove this final reference from the README.