### PR TITLE
NPE when `actual_ship_date` is None

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -232,8 +232,10 @@ https://access.redhat.com/articles/11258")
             # Actual ship date (if in SHIPPED_LIVE)
             if self.errata_state in ('SHIPPED_LIVE'):
                 d = erratum['actual_ship_date']
-                d = time.strptime(str(d), '%Y-%m-%dT%H:%M:%SZ')
-                self.ship_date = time.strftime('%Y-%b-%d', d)
+                # Could be None. e.g. advisory 43686
+                if d:
+                    d = time.strptime(str(d), '%Y-%m-%dT%H:%M:%SZ')
+                    self.ship_date = time.strftime('%Y-%b-%d', d)
 
             # File date
             d = erratum['created_at']


### PR DESCRIPTION
We recently hit an NPE with `errata_tool.Erratum()`, which breaks a lot of our automation using this library. We found some shipped advisories has `actual_ship_date` set to `null` but errata_tool always tries to format that field to string. This PR just adds a simple NPE check.

For example, https://errata.devel.redhat.com/api/v1/erratum/43686:

```
advisory = errata_tool.Erratum(errata_id=43686)
  File "/home/dev/.local/lib/python2.7/site-packages/errata_tool/erratum.py", line 131, in __init__
    self._fetch(kwargs['errata_id'])
  File "/home/dev/.local/lib/python2.7/site-packages/errata_tool/erratum.py", line 235, in _fetch
    d = time.strptime(str(d), '%Y-%m-%dT%H:%M:%SZ')
  File "/usr/lib64/python2.7/_strptime.py", line 478, in _strptime_time
    return _strptime(data_string, format)[0]
  File "/usr/lib64/python2.7/_strptime.py", line 332, in _strptime
    (data_string, format))
ValueError: time data 'None' does not match format '%Y-%m-%dT%H:%M:%SZ'
```