### PR TITLE
build: lazy-load erratum when asked for

### DIFF
--- a/errata_tool/tests/test_build.py
+++ b/errata_tool/tests/test_build.py
@@ -31,3 +31,10 @@ class TestGet(object):
 
     def test_get(self, build):
         assert build.id == 760518
+
+    def test_all_errata_ids(self, build):
+        assert len(build.all_errata_ids) == 1
+        assert build.all_errata_ids == [33840]
+
+    def test_released_errata_id(self, build):
+        assert build.released_errata_id == 33840


### PR DESCRIPTION
- reworked _fetch to extract all_errataum_ids and released_errata_id
- reworked _fetch to not create erratum objects
- only load/create erratum objects when asked for
- added all_erratum_ids and released_errata_id properties

Performance improvement of build search object, only load/populate Erratum when you need them.  Allowing property accessors to the list of errata_id's without the time penalty of populating full Erratum objects.

Resolves: https://github.com/red-hat-storage/errata-tool/issues/179