### PR TITLE
tests: fix release.blocker_flags test

### DIFF
--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -23,8 +23,8 @@ class TestGet(object):
     def test_enabled(self, release):
         assert release.enabled is True
 
-    def blocker_flags(self, release):
-        expected = ['ceph-3.y', 'pm_ack', 'devel_ack', 'qa_ack']
+    def test_blocker_flags(self, release):
+        expected = ['ceph-3.y', 'devel_ack', 'qa_ack', 'pm_ack']
         assert release.blocker_flags == expected
 
     def test_product_versions(self, release):


### PR DESCRIPTION
Prior to this change, pytest was not invoking the blocker_flags() method
because it did not start with "test\_". Rename the method so that pytest
invokes it.

Our "expected" values were ordered incorrectly when compared to our test
fixture data. Re-order the expected flags so that "pm_ack" is the final
one.

With these changes, pytest properly exercises .blocker_flags attribute.