### PR TITLE
Batch subcommand filter

### DIFF
--- a/errata_tool/cli/batch.py
+++ b/errata_tool/cli/batch.py
@@ -1,0 +1,43 @@
+from errata_tool.connector import ErrataConnector
+
+
+def add_parser(subparsers):
+    """Add our batcj parser to this top-level subparsers object. """
+    group = subparsers.add_parser('batch', help='Get batch Details')
+
+    # advisory-level subcommands:
+    sub = group.add_subparsers(dest='batch_subcommand')
+    sub.required = True
+
+    # "get"
+    get_parser = sub.add_parser('get')
+    get_parser.add_argument('batch_name_or_id', help='batch name or id, "12345" or "<batch name>"')
+    get_parser.set_defaults(func=get)
+
+    # "list"
+    list_parser = sub.add_parser('list')
+    list_parser.set_defaults(func=list_func)
+
+def get_errata_by_batch(connector, batch_name_or_id):
+    """search for and return list of errata by name or id of batch"""
+    args = {}
+
+    try:
+        args['id'] = int(batch_name_or_id)
+    except ValueError:
+        args['name'] = batch_name_or_id
+
+    data = connector.get_filter('/api/v1/batches', 'filter', **args)
+
+    return data
+
+def get(args):
+    et = ErrataConnector()
+    e = get_errata_by_batch(et, args.batch_name_or_id)
+    print(e)
+
+
+def list_func(args):
+    et = ErrataConnector()
+    e = et._get('/api/v1/batches')
+    print(e)

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -77,6 +77,14 @@ def mock_put():
 
 
 @pytest.fixture
+def sample_connector(monkeypatch, mock_get):
+    monkeypatch.delattr('requests.sessions.Session.request')
+    monkeypatch.setattr(ErrataConnector, '_auth', None)
+    monkeypatch.setattr(ErrataConnector, '_username', 'test')
+    monkeypatch.setattr(requests, 'get', mock_get)
+    return ErrataConnector()
+
+@pytest.fixture
 def advisory(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)

--- a/errata_tool/tests/test_filter.py
+++ b/errata_tool/tests/test_filter.py
@@ -1,0 +1,33 @@
+import requests
+
+
+class TestFilter(object):
+
+    def test_filter_none(self, sample_connector):
+        assert sample_connector.get_filter(None, None) is None
+
+    def test_filter_sample(self, sample_connector):
+        assert sample_connector.get_filter(
+            '/api/v1/releases', 'filter', name='rhceph-3.1')
+
+    def test_filter_sample_check_url(self, monkeypatch, mock_get,
+                                     sample_connector):
+        monkeypatch.setattr(requests, 'get', mock_get)
+        assert sample_connector.get_filter(
+            '/api/v1/releases', 'filter', name='rhceph-3.1')
+        assert 'page' not in mock_get.response.url
+
+    def test_filter_url_paginated_false(self, monkeypatch,
+                                        mock_get, sample_connector):
+        monkeypatch.setattr(requests, 'get', mock_get)
+        assert sample_connector.get_filter(
+            '/api/v1/releases', 'filter', name='rhceph-3.1', paginated=False)
+        assert 'page' not in mock_get.response.url
+
+    def test_filter_sample_check_url_paginated(self, monkeypatch, mock_get,
+                                               sample_connector):
+        monkeypatch.setattr(requests, 'get', mock_get)
+        assert sample_connector.get_filter(
+            '/api/v1/external_tests/', 'filter', errata_id='33840',
+            test_type='rpmdiff', active='true', paginated=True)
+        assert 'page' in mock_get.response.url


### PR DESCRIPTION
simple batch subcommand using get_filter implementation

get_filter abstracts several filter request patterns for paginated and
non-paginated get interactions with errata