### PR TITLE
Update security impact field for an existing RHSA advisory

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -774,12 +774,6 @@ https://access.redhat.com/articles/11258")
             if self.errata_type is None:
                 self.errata_type = 'RHBA'
 
-            if self.errata_type == 'RHSA':
-                val = 'None'
-                if self.security_impact is not None:
-                    val = self.security_impact
-                pdata['advisory[security_impact]'] = val
-
             pdata['product'] = self._product
             pdata['release'] = self._release
             pdata['advisory[package_owner_email]'] = self.package_owner_email
@@ -823,6 +817,12 @@ https://access.redhat.com/articles/11258")
             severity = r'^(Low|Moderate|Important|Critical): '
             self.synopsis = re.sub(severity, "", self.synopsis)
             pdata['advisory[cve]'] = self.cve_names
+
+            val = 'None'
+            if self.security_impact is not None:
+                val = self.security_impact
+            pdata['advisory[security_impact]'] = val
+
         pdata['advisory[synopsis]'] = self.synopsis
         pdata['advisory[topic]'] = self.topic
         pdata['advisory[description]'] = self.description


### PR DESCRIPTION
While working with @sosiouxme (cc: @thiagoalessio) on an [Elliott issue](https://github.com/openshift/elliott/pull/172) we found that errata_tool returned a server error when there's an attempt to update an existing advisory's security impact, i.e. 

`advisory.update(security_impact=<val>)`

It turned out that security_impact field is only set in case of **new** RHSA advisories, so the fix was simply moving the block outside of new block. 

This is my first time contributing to ET, so I'm not aware of what exactly I need to do to get this fixed (or if it is even an issue..). I can write a unit test or two if that's recommended. @ktdreyer @yazug Please advice, thank you.