### PR TITLE
rpm: remove comments after %endif directives

### DIFF
--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -55,7 +55,7 @@ Modern Python API to Red Hat's Errata Tool
 
 %if 0%{?with_python3}
 cp -a . %{py3dir}
-%endif # with_python3
+%endif
 
 %build
 %if 0%{?el7}
@@ -77,7 +77,7 @@ export PYTHONPATH=$(pwd)
 py.test-%{python2_version} -v errata_tool/tests
 %else
 py.test-%{python3_version} -v errata_tool/tests
-%endif # with_python3
+%endif
 
 %if 0%{?el7}
 %files


### PR DESCRIPTION
rpmlint and modern RPM versions warn about the comments after the `%endif` directives.

```
python-errata-tool.spec: E: specfile-error warning: extra tokens at the end of %endif directive in line 58:  %endif # with_python3
```

The conditionals are so small that it's fairly easy to read what the code is doing. Remove the comments to silence this error message.