### PR TITLE
erratum: fix updating owner and manager emails

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -776,9 +776,11 @@ https://access.redhat.com/articles/11258")
 
             pdata['product'] = self._product
             pdata['release'] = self._release
-            pdata['advisory[package_owner_email]'] = self.package_owner_email
-            pdata['advisory[manager_email]'] = self.manager_email
 
+        if self.package_owner_email is not None:
+            pdata['advisory[package_owner_email]'] = self.package_owner_email
+        if self.manager_email is not None:
+            pdata['advisory[manager_email]'] = self.manager_email
         if self.qe_email is not None and self.qe_email != '':
             pdata['advisory[assigned_to_email]'] = self.qe_email
         if self.qe_group is not None and self.qe_group != '':


### PR DESCRIPTION
Prior to this commit, users could not update owner and manager email addresses for existing advisories. We sent the parameters when creating a new advisory, but not when editing an existing advisory.

Move the pdata assignments out of the `if self._new` conditional so that we send these parameters during advisory creations and updates.

Fixes: #208