### PR TITLE
tests: use recwarn.list for EPEL 7's pytest 2.7.0

### DIFF
--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -142,5 +142,5 @@ class TestSpecialCharacters(object):
         assert mock_get.response.url == self.expected_url
         assert mock_get.kwargs['params']['filter[name]'] == \
             'RHEL-8.4.0.Z.MAIN+EUS'
-        assert len(recwarn) == 1
+        assert len(recwarn.list) == 1
         assert recwarn.pop(DeprecationWarning)


### PR DESCRIPTION
EPEL 7 has pytest v2.7.0, and `len(recwarn)` only works in pytest 2.8.0+. Use the older `recwarn.list` syntax so that the test suite passes in an EPEL 7 chroot.