### PR TITLE
revert _username handling and replace requests-kerberos with requests-gssapi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 Modern Python API to Red Hat's Errata Tool.
 
 python-errata-tool is a Python library that wraps the Errata Tool's REST API.
-It uses `requests_kerberos <https://pypi.python.org/pypi/requests-kerberos>`_
+It uses `requests_gssapi <https://pypi.python.org/pypi/requests-gssapi>`_
 to authenticate and parses JSON responses into ``Erratum`` objects. You can
 use it to create new advisories, or read and update existing advisories. The
 ``ErratumConnector`` class also provides lower-level access to all of the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ if on_rtd:
         def __getattr__(cls, name):
             return MagicMock()
 
-    MOCK_MODULES = ['requests_kerberos', 'jsonpath_rw']
+    MOCK_MODULES = ['requests_gssapi' 'jsonpath_rw']
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ if on_rtd:
         def __getattr__(cls, name):
             return MagicMock()
 
-    MOCK_MODULES = ['requests_kerberos', 'kerberos', 'jsonpath_rw']
+    MOCK_MODULES = ['requests_kerberos', 'jsonpath_rw']
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ python-errata-tool
 About
 -----
 python-errata-tool is a Python library that wraps the Errata Tool's REST API.
-It uses `requests_kerberos <https://pypi.python.org/pypi/requests-kerberos>`_
+It uses `requests_gssapi <https://pypi.python.org/pypi/requests-gssapi>`_
 to authenticate and parses JSON responses into
 :class:`~errata_tool.erratum.Erratum` objects. You can use it to create new
 advisories, or read and update existing advisories. The

--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from errata_tool import ErrataException
 import requests
-from requests_kerberos import HTTPKerberosAuth, DISABLED
+from requests_gssapi import HTTPSPNEGOAuth
 from jsonpath_rw import parse
 import re
 import time
@@ -11,7 +11,7 @@ import six
 class ErrataConnector(object):
     # Staging is https://errata.stage.engineering.redhat.com
     _url = "https://errata.devel.redhat.com"
-    _auth = HTTPKerberosAuth(mutual_authentication=DISABLED)
+    _auth = HTTPSPNEGOAuth()
     ssl_verify = True  # Shared
     debug = False
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import datetime
 import os
 import re
-import requests_kerberos
 import six
 import textwrap
 import time
@@ -898,11 +897,7 @@ https://access.redhat.com/articles/11258")
             pdata = {}
             pdata['bug[' + str(last_bug) + ']'] = 1
 
-            # Handle weird interaction we get in this particular case
-            try:
-                r = self._post(url, data=pdata)
-            except requests_kerberos.exceptions.MutualAuthenticationError:
-                pass
+            r = self._post(url, data=pdata)
             self._processResponse(r)
 
     def _putStatus(self):

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -92,7 +92,6 @@ def mock_put():
 def advisory(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Erratum(errata_id=33840)
 
@@ -101,7 +100,6 @@ def advisory(monkeypatch, mock_get):
 def advisory_none_ship(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Erratum(errata_id=43686)
 
@@ -110,7 +108,6 @@ def advisory_none_ship(monkeypatch, mock_get):
 def advisory_with_batch(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Erratum(errata_id=46563)
 
@@ -120,7 +117,6 @@ def rhsa(monkeypatch, mock_get):
     """Like the advisory() fixture above, but an RHSA. """
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Erratum(errata_id=36762)
 
@@ -129,7 +125,6 @@ def rhsa(monkeypatch, mock_get):
 def productlist(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return ProductList()
 
@@ -138,7 +133,6 @@ def productlist(monkeypatch, mock_get):
 def product(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Product('RHCEPH')
 
@@ -147,7 +141,6 @@ def product(monkeypatch, mock_get):
 def rhacm_product(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Product('RHACM')
 
@@ -155,7 +148,6 @@ def rhacm_product(monkeypatch, mock_get):
 def product_version(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return ProductVersion('RHEL-7-RHCEPH-3.1')
 
@@ -164,7 +156,6 @@ def product_version(monkeypatch, mock_get):
 def release(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Release(name='rhceph-3.1')
 
@@ -173,7 +164,6 @@ def release(monkeypatch, mock_get):
 def build(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Build('ceph-12.2.5-42.el7cp')
 
@@ -182,7 +172,6 @@ def build(monkeypatch, mock_get):
 def rhceph_variant(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Variant(name='8Base-RHCEPH-5.0-MON')
 
@@ -191,6 +180,5 @@ def rhceph_variant(monkeypatch, mock_get):
 def rhacm_variant(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(ErrataConnector, '_username', 'test')
     monkeypatch.setattr(requests, 'get', mock_get)
     return Variant(name='7Server-RHACM-2.0')

--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -1,7 +1,6 @@
 from datetime import date
 import requests
 from errata_tool.release import Release
-from errata_tool.connector import ErrataConnector
 
 
 class TestGet(object):
@@ -88,7 +87,6 @@ class TestCreate(object):
     def test_create_url(self, monkeypatch, mock_get, mock_post):
         monkeypatch.setattr(requests, 'get', mock_get)
         monkeypatch.setattr(requests, 'post', mock_post)
-        monkeypatch.setattr(ErrataConnector, '_username', 'test')
         Release.create(**self.create_kwargs)
         expected = 'https://errata.devel.redhat.com/release/create'
         assert mock_post.response.url == expected
@@ -96,7 +94,6 @@ class TestCreate(object):
     def test_create_data(self, monkeypatch, mock_get, mock_post):
         monkeypatch.setattr(requests, 'get', mock_get)
         monkeypatch.setattr(requests, 'post', mock_post)
-        monkeypatch.setattr(ErrataConnector, '_username', 'test')
         Release.create(**self.create_kwargs)
         today = date.today()
         ship_date = today.strftime("%Y-%b-%d")
@@ -127,7 +124,6 @@ class TestSpecialCharacters(object):
 
     def test_plus(self, monkeypatch, mock_get):
         monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(ErrataConnector, '_username', 'test')
         release = Release(name='RHEL-8.4.0.Z.MAIN+EUS')
         assert release.name == 'RHEL-8.4.0.Z.MAIN+EUS'
         assert mock_get.response.url == self.expected_url
@@ -136,7 +132,6 @@ class TestSpecialCharacters(object):
 
     def test_plus_encoded(self, monkeypatch, mock_get, recwarn):
         monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(ErrataConnector, '_username', 'test')
         release = Release(name='RHEL-8.4.0.Z.MAIN%2BEUS')
         assert release.name == 'RHEL-8.4.0.Z.MAIN+EUS'
         assert mock_get.response.url == self.expected_url

--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -16,14 +16,14 @@ BuildArch:      noarch
 BuildRequires:  pytest
 BuildRequires:  python2-devel
 BuildRequires:  python-jsonpath-rw
-BuildRequires:  python-requests-kerberos
+BuildRequires:  python-requests-gssapi
 BuildRequires:  python-setuptools
 BuildRequires:  python-six
 %else
 BuildRequires:  python3-devel
 BuildRequires:  python3-jsonpath-rw
 BuildRequires:  python3-pytest
-BuildRequires:  python3-requests-kerberos
+BuildRequires:  python3-requests-gssapi
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
 %endif
@@ -33,14 +33,14 @@ Modern Python API to Red Hat's Errata Tool
 
 
 %if 0%{?el7}
-Requires:  python-requests-kerberos
+Requires:  python-requests-gssapi
 Requires:  python-jsonpath-rw
 Requires:  python-six
 %else
 %package -n python3-%{pkgname}
 Summary:    %{summary}
 Requires:   python3 >= 3.5
-Requires:   python3-requests-kerberos
+Requires:   python3-requests-gssapi
 Requires:   python3-jsonpath-rw
 Requires:   python3-six
 

--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -36,7 +36,6 @@ Modern Python API to Red Hat's Errata Tool
 Requires:  python-requests-kerberos
 Requires:  python-jsonpath-rw
 Requires:  python-six
-Requires:  python-kerberos
 %else
 %package -n python3-%{pkgname}
 Summary:    %{summary}

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
     install_requires=[
         'jsonpath_rw',
         'requests',
-        'requests_kerberos',
+        'requests_gssapi',
         'six',
     ],
     cmdclass={'bump': BumpCommand, 'release': ReleaseCommand},

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ setup(
         'jsonpath_rw',
         'requests',
         'requests_kerberos',
-        'kerberos',
         'six',
     ],
     cmdclass={'bump': BumpCommand, 'release': ReleaseCommand},


### PR DESCRIPTION
Remove the username discovery in connector.py. The `self._username` property is not easy to support with the switch from python-kerberos to python-gssapi.

requests-kerberos is not well-maintained upstream and Fedora is dropping it entirely. requests-gssapi is an up-to-date replacement.

Fixes: #135