### PR TITLE
Add a dump-config CLI subcommand

### DIFF
--- a/errata_tool/cli/dump-config.py
+++ b/errata_tool/cli/dump-config.py
@@ -1,0 +1,47 @@
+from sys import stdout, version_info
+import yaml
+import warnings
+from errata_tool.product import Product
+from errata_tool.variant import Variant
+
+MIN_PYTHON = (3, 7)
+if version_info < MIN_PYTHON:
+    warnings.warn("Run with Python 3.7+ for ordered YAML output")
+
+
+def add_parser(subparsers):
+    """Add our dump-config parser to this top-level subparsers object. """
+    group = subparsers.add_parser('dump-config', help='Get a product')
+
+    # dump-config-level subcommands:
+    sub = group.add_subparsers(dest='dump-config_subcommand')
+    sub.required = True
+
+    # "get"
+    get_parser = sub.add_parser('get')
+    get_parser.add_argument('name', help='eg. "RHCEPH"')
+    get_parser.set_defaults(func=get)
+
+
+def get(args):
+    product = Product(name=args.name)
+    product_rendered = [product.render()]
+
+    release_groups_rendered = []
+
+    for release in product.releases():
+        release_groups_rendered.append(release.render())
+
+    cdn_repos_rendered = []
+    for product_version in product_rendered[0]['product_versions']:
+        for variant in product_version['variants']:
+            for cdn_repo in Variant(name=variant['name']).cdn_repos():
+                cdn_repos_rendered.append(cdn_repo.render())
+
+    output = {
+        'products': product_rendered,
+        'release_groups': release_groups_rendered,
+        'cdn_repos': sorted(cdn_repos_rendered, key=lambda x: x['name'])
+    }
+
+    yaml.dump(output, stdout, sort_keys=False)

--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -14,6 +14,7 @@ Source0:        %{pkgname}-%{version}.tar.gz
 BuildArch:      noarch
 %if 0%{?el7}
 BuildRequires:  pytest
+BuildRequires:  PyYAML
 BuildRequires:  python2-devel
 BuildRequires:  python-jsonpath-rw
 BuildRequires:  python-requests-gssapi
@@ -23,6 +24,7 @@ BuildRequires:  python-six
 BuildRequires:  python3-devel
 BuildRequires:  python3-jsonpath-rw
 BuildRequires:  python3-pytest
+BuildRequires:  python3-pyyaml
 BuildRequires:  python3-requests-gssapi
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
@@ -33,6 +35,7 @@ Modern Python API to Red Hat's Errata Tool
 
 
 %if 0%{?el7}
+Requires:  PyYAML
 Requires:  python-requests-gssapi
 Requires:  python-jsonpath-rw
 Requires:  python-six
@@ -42,6 +45,7 @@ Summary:    %{summary}
 Requires:   python3 >= 3.5
 Requires:   python3-requests-gssapi
 Requires:   python3-jsonpath-rw
+Requires:   python3-pyyaml
 Requires:   python3-six
 
 %description -n python3-%{pkgname}

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     install_requires=[
         'jsonpath_rw',
+        'pyyaml',
         'requests',
         'requests_gssapi',
         'six',


### PR DESCRIPTION
This change adds a frontend for dumping many of the most relevant
data fields in a product's ET configuration which allows for easy
introspection as well as provides an easy migration path to porting
to ansible configurations.

Signed-off-by: Joshua Stone <jostone@redhat.com>