### PR TITLE
make: VERSION assignment on py3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 NAME = python-errata-tool
 VERSION := $(shell PYTHONPATH=. python -c \
-             'import errata_tool; print errata_tool.__version__')
+             'import errata_tool; print(errata_tool.__version__)')
 RELEASE := $(shell rpmspec \
              --define "dist .el7" \
              -q --srpm --qf "%{release}\n" python-errata-tool.spec)


### PR DESCRIPTION
In Fedora 31+, `python` means `python3`. https://fedoraproject.org/wiki/Changes/Python_means_Python3

On these platforms, we need to use the `print()` function in order to properly assign the `VERSION` variable.