### PR TITLE
Avoid populating CDN repo entries in dump-config with duplicates

### DIFF
--- a/errata_tool/cli/dump-config.py
+++ b/errata_tool/cli/dump-config.py
@@ -36,7 +36,9 @@ def get(args):
     for product_version in product_rendered[0]['product_versions']:
         for variant in product_version['variants']:
             for cdn_repo in Variant(name=variant['name']).cdn_repos():
-                cdn_repos_rendered.append(cdn_repo.render())
+                cdn_repos = [repo['name'] for repo in cdn_repos_rendered]
+                if cdn_repo.name not in cdn_repos:
+                    cdn_repos_rendered.append(cdn_repo.render())
 
     output = {
         'products': product_rendered,


### PR DESCRIPTION
The dump-config functionality in errata-tool does not check for
duplicate CDN repos, which can occur with repos that are part of
multiple variants. This change adds a check to avoid duplicates in
dump-config output.