### PR TITLE
fix: #222 - e.metadataCdnRepos and...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,7 +277,7 @@ containing Docker images):
     e = Erratum(errata_id=24075)
 
     assert 'docker' in e.content_types
-    e.metadataCdnRepos(enable='rhel-7-server-rhceph-3-mon-rpms__x86_64')
+    e.metadataCdnRepos(enable=['rhel-7-server-rhceph-3-mon-rpms__x86_64'])
 
 Same thing, but for text-only advisories:
 
@@ -286,7 +286,7 @@ Same thing, but for text-only advisories:
     e = Erratum(errata_id=24075)
 
     assert e.text_only
-    e.textOnlyRepos(enable='rhel-7-server-rhceph-3-mon-rpms__x86_64')
+    e.textOnlyRepos(enable=['rhel-7-server-rhceph-3-mon-rpms__x86_64'])
 
 
 Working with products


### PR DESCRIPTION
fix: #222 - e.metadataCdnRepos and e.textOnlyRepos must use lists of strings, not just single strings

Change-Id: I3b77a255b385998fb0678919efcd33f6c806f14d
Signed-off-by: nickboldt <nboldt@redhat.com>