### PR TITLE
Add allow_rhn_debuginfo to ProductVersion render output

### DIFF
--- a/errata_tool/product_version.py
+++ b/errata_tool/product_version.py
@@ -58,6 +58,7 @@ class ProductVersion(ErrataConnector):
                 str(target['name'])
                 for target in self.relationships['push_targets']
             ],
+            'allow_rhn_debuginfo': self.allow_rhn_debuginfo,
             'variants': [
                 variant.render()
                 for variant in self.variants()

--- a/errata_tool/tests/test_product_version.py
+++ b/errata_tool/tests/test_product_version.py
@@ -28,7 +28,8 @@ def test_released_builds(product_version):
 
 def test_product_version_pretty_print(product_version):
     pretty_printer = pprint.PrettyPrinter()
-    output = """{'brew_tags': ['ceph-3.1-rhel-7-candidate'],
+    output = """{'allow_rhn_debuginfo': False,
+ 'brew_tags': ['ceph-3.1-rhel-7-candidate'],
  'default_brew_tag': 'ceph-3.1-rhel-7-candidate',
  'description': 'Red Hat Ceph Storage 3.1',
  'enabled': False,


### PR DESCRIPTION
Some product versions have allow_rhn_debuginfo disabled, which
leads to an incomplete product configuration dump. This change adds
that property to the render output.