### PR TITLE
Include jira issues when updating advisory

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -564,7 +564,7 @@ https://access.redhat.com/articles/11258")
     def _addJiraIssue(self, j):
         if not isinstance(j, str):
             raise ErrataException('JIRA issue must be a string and'
-                                  f' not a {type(j)}')
+                                  ' not a {}'.format(type(j)))
         if j not in self.jira_issues:
             self.jira_issues.append(j)
 
@@ -578,7 +578,7 @@ https://access.redhat.com/articles/11258")
     def _removeJiraIssue(self, j):
         if not isinstance(j, str):
             raise ErrataException('JIRA issue must be a string and'
-                                  f' not a {type(j)}')
+                                  ' not a {}'.format(type(j)))
         if j in self.jira_issues:
             self.jira_issues.remove(j)
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -869,7 +869,8 @@ https://access.redhat.com/articles/11258")
         pdata['advisory[idsfixed]'] = idsfixed
 
         # Sync newly added bug states
-        newbugs = list(set(allbugs) - set(self._original_bugs) - set(self._original_jira_issues))
+        newbugs = list(set(allbugs) - set(self._original_bugs) -
+                       set(self._original_jira_issues))
         if len(newbugs):
             # url = '/api/v1/bug/refresh'
             # print(allbugs)

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -1124,7 +1124,8 @@ https://access.redhat.com/articles/11258")
             "\n  batch_id:    " + str(self.batch_id) + \
             "\n  ship date:   " + str(self.ship_date) + \
             "\n  age:         " + str(self.age) + " days" \
-            "\n  bugs:        " + str(self.errata_bugs + self.jira_issues) + \
+            "\n  bugs:        " + str(sorted(self.errata_bugs)) + \
+            "\n  jira issues: " + str(sorted(self.jira_issues)) + \
             s
 
     def __int__(self):

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -866,7 +866,8 @@ https://access.redhat.com/articles/11258")
             self.errata_bugs = [last_bug]
 
         # Add back any Vulnerability bugs
-        allbugs = list(set(self.errata_bugs) | set(self._cve_bugs) | set(self.jira_issues))
+        allbugs = list(set(self.errata_bugs) | set(
+            self._cve_bugs) | set(self.jira_issues))
         idsfixed = ' '.join(str(i) for i in allbugs)
         pdata['advisory[idsfixed]'] = idsfixed
 
@@ -964,7 +965,8 @@ https://access.redhat.com/articles/11258")
 
             # Update buglist if it changed
             # Errata tool is very slow - don't PUT if it hasn't changed
-            allbugs = list(set(self.errata_bugs) | set(self._cve_bugs) | set(self.jira_issues))
+            allbugs = list(set(self.errata_bugs) | set(
+                self._cve_bugs) | set(self.jira_issues))
             if sorted(self._original_bugs) != sorted(allbugs) \
                or self._update:
                 self._write()

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -18,11 +18,11 @@ class Erratum(ErrataConnector):
         lines = s.split('\n')
 
         page = []
-        for l in lines:
+        for line in lines:
             b = textwrap.TextWrapper(width=75, replace_whitespace=True,
                                      break_long_words=False,
                                      break_on_hyphens=False)
-            page.append(b.fill(l))
+            page.append(b.fill(line))
         return '\n'.join(page)
 
     def _do_init(self):
@@ -563,7 +563,8 @@ https://access.redhat.com/articles/11258")
 
     def _addJiraIssue(self, j):
         if not isinstance(j, str):
-            raise ErrataException(f'JIRA issue must be a string and not a {type(j)}')
+            raise ErrataException('JIRA issue must be a string and'
+                                  f' not a {type(j)}')
         if j not in self.jira_issues:
             self.jira_issues.append(j)
 
@@ -575,8 +576,9 @@ https://access.redhat.com/articles/11258")
             self._addJiraIssue(j)
 
     def _removeJiraIssue(self, j):
-        if not isinstance(b, str):
-            raise ErrataException(f'JIRA issue must be a string and not a {type(j)}')
+        if not isinstance(j, str):
+            raise ErrataException('JIRA issue must be a string and'
+                                  f' not a {type(j)}')
         if j in self.jira_issues:
             self.jira_issues.remove(j)
 

--- a/errata_tool/product_version.py
+++ b/errata_tool/product_version.py
@@ -1,6 +1,7 @@
 from errata_tool import ErrataConnector
 from errata_tool.variant import Variant
 
+
 class ProductVersion(ErrataConnector):
     def __init__(self, id_or_name, data=None):
         """Find a Product Version in the ET database.

--- a/errata_tool/release.py
+++ b/errata_tool/release.py
@@ -4,7 +4,6 @@ import warnings
 from datetime import date
 import errata_tool
 from errata_tool import ErrataConnector
-from errata_tool.product import Product
 from errata_tool.product_version import ProductVersion
 from errata_tool.user import User
 

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -144,6 +144,7 @@ def rhacm_product(monkeypatch, mock_get):
     monkeypatch.setattr(requests, 'get', mock_get)
     return Product('RHACM')
 
+
 @pytest.fixture
 def product_version(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')

--- a/errata_tool/tests/test_product_version.py
+++ b/errata_tool/tests/test_product_version.py
@@ -1,5 +1,6 @@
 import pprint
 
+
 def test_id(product_version):
     assert product_version.id == 783
 

--- a/errata_tool/tests/test_variant.py
+++ b/errata_tool/tests/test_variant.py
@@ -1,5 +1,6 @@
 import pprint
 
+
 def test_id(rhceph_variant):
     assert rhceph_variant.id == 3085
 

--- a/errata_tool/variant.py
+++ b/errata_tool/variant.py
@@ -1,6 +1,7 @@
 from errata_tool import ErrataConnector
 from errata_tool.cdn_repo import CdnRepo
 
+
 class Variant(ErrataConnector):
     """A Variant contains a "data" dict, for example::
     {


### PR DESCRIPTION
Noticed that when updating an advisory, we
were missing to include jira_issues in "idsfixed"
This was causing jira issues to be removed
from an advisory.

https://errata.devel.redhat.com/developer-guide/api-http-api.html#api-post-apiv1erratum
