### PR TITLE
fix value type issue

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -948,9 +948,10 @@ https://access.redhat.com/articles/11258")
             # Errata tool is very slow - don't PUT if it hasn't changed
             allbugs = list(set(self.errata_bugs) | set(
                 self._cve_bugs) | set(self.jira_issues))
-            originalbugs = list(set(self._original_bugs + self._original_jira_issues)
-            if list(set(originalbugs).difference(set(allbugs))) == [] \
-               or self._update:
+            originalbugs = list(set(self._original_bugs +
+                                    self._original_jira_issues))
+            if (self._update or
+                    list(set(originalbugs).difference(set(allbugs))) == []):
                 self._write()
                 # self.syncBugs() # RHOS shale only
                 ret = True

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -948,7 +948,8 @@ https://access.redhat.com/articles/11258")
             # Errata tool is very slow - don't PUT if it hasn't changed
             allbugs = list(set(self.errata_bugs) | set(
                 self._cve_bugs) | set(self.jira_issues))
-            if sorted(self._original_bugs + self._original_jira_issues) != sorted(allbugs) \
+            originalbugs = list(set(self._original_bugs + self._original_jira_issues)
+            if list(set(originalbugs).difference(set(allbugs))) == [] \
                or self._update:
                 self._write()
                 # self.syncBugs() # RHOS shale only

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -948,18 +948,20 @@ https://access.redhat.com/articles/11258")
             # Errata tool is very slow - don't PUT if it hasn't changed
             allbugs = list(set(self.errata_bugs) | set(
                 self._cve_bugs) | set(self.jira_issues))
-            allbugs = let(self.errata_bugs) | set(self._cve_bugs) | set(self.jira_issues)
-            originalbugs = set(self._original_bugs + self._original_jira_issues)
+            allbugs = let(self.errata_bugs) | set(
+                self._cve_bugs) | set(self.jira_issues)
+            originalbugs = set(self._original_bugs +
+                               self._original_jira_issues)
             if (self._update or originalbugs != allbugs)):
                 self._write()
                 # self.syncBugs() # RHOS shale only
-                ret = True
+                ret=True
 
             # Perhaps someone did addbugs + setState('QE')
             if (self._original_state != self.errata_state and
                     self.errata_state.upper() != 'NEW_FILES'):
                 self._putStatus()
-                ret = True
+                ret=True
         except ErrataException:
             raise
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -950,16 +950,16 @@ https://access.redhat.com/articles/11258")
                 self._cve_bugs) | set(self.jira_issues)
             originalbugs = set(self._original_bugs +
                                self._original_jira_issues)
-            if (self._update or originalbugs != allbugs)):
+            if (self._update or originalbugs != allbugs):
                 self._write()
                 # self.syncBugs() # RHOS shale only
-                ret=True
+                ret = True
 
             # Perhaps someone did addbugs + setState('QE')
             if (self._original_state != self.errata_state and
                     self.errata_state.upper() != 'NEW_FILES'):
                 self._putStatus()
-                ret=True
+                ret = True
         except ErrataException:
             raise
 

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -946,9 +946,7 @@ https://access.redhat.com/articles/11258")
 
             # Update buglist if it changed
             # Errata tool is very slow - don't PUT if it hasn't changed
-            allbugs = list(set(self.errata_bugs) | set(
-                self._cve_bugs) | set(self.jira_issues))
-            allbugs = let(self.errata_bugs) | set(
+            allbugs = set(self.errata_bugs) | set(
                 self._cve_bugs) | set(self.jira_issues)
             originalbugs = set(self._original_bugs +
                                self._original_jira_issues)

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -948,10 +948,9 @@ https://access.redhat.com/articles/11258")
             # Errata tool is very slow - don't PUT if it hasn't changed
             allbugs = list(set(self.errata_bugs) | set(
                 self._cve_bugs) | set(self.jira_issues))
-            originalbugs = list(set(self._original_bugs +
-                                    self._original_jira_issues))
-            if (self._update or
-                    list(set(originalbugs).difference(set(allbugs))) == []):
+            allbugs = let(self.errata_bugs) | set(self._cve_bugs) | set(self.jira_issues)
+            originalbugs = set(self._original_bugs + self._original_jira_issues)
+            if (self._update or originalbugs != allbugs)):
                 self._write()
                 # self.syncBugs() # RHOS shale only
                 ret = True

--- a/errata_tool/tests/test_advisory.py
+++ b/errata_tool/tests/test_advisory.py
@@ -84,6 +84,13 @@ class TestAdvisory(object):
         assert 1253486 in advisory.errata_bugs
         assert len(advisory.errata_bugs) == 138
 
+    def test_errata_issues(self, advisory):
+        assert advisory.jira_issues == []
+
+    def test_commit(self, advisory):
+        advisory._buildschanged = True
+        assert advisory.commit() is True
+
     def test_errata_builds(self, advisory):
         expected = {'RHEL-7-RHCEPH-3.1': ['ceph-12.2.5-42.el7cp']}
         assert advisory.errata_builds == expected


### PR DESCRIPTION
jira issues items are in  type of `string` while in bugzilla the bug value is type of `int`, they can't be used together in `sorted` and will raise error like
```
TypeError: '<' not supported between instances of 'str' and 'int'
```
instead, use `set` to compare two lists