### PR TITLE
Add use_quay_for_containers to ProductVersion render output

### DIFF
--- a/errata_tool/product_version.py
+++ b/errata_tool/product_version.py
@@ -55,6 +55,7 @@ class ProductVersion(ErrataConnector):
             'rhel_release_name': rhel_release,
             'brew_tags': brew_tags,
             'is_server_only': self.is_server_only,
+            'use_quay_for_containers': self.use_quay_for_containers,
             'push_targets': [
                 str(target['name'])
                 for target in self.relationships['push_targets']

--- a/errata_tool/tests/test_product_version.py
+++ b/errata_tool/tests/test_product_version.py
@@ -39,6 +39,7 @@ def test_product_version_pretty_print(product_version):
  'push_targets': ['ftp', 'cdn_stage', 'cdn_docker_stage', 'cdn_docker', 'cdn'],
  'rhel_release_name': 'RHEL-7',
  'sig_key_name': 'redhatrelease2',
+ 'use_quay_for_containers': False,
  'variants': [{'description': 'Red Hat Ceph Storage 3.1 MON',
                'enabled': True,
                'name': '7Server-RHEL-7-RHCEPH-3.1-MON',


### PR DESCRIPTION
Errata Tool added use_quay_for_containers which some products are starting to use but may introduce regressions, which in turn may not be obvious based on the current product configuration dump. This change adds that property to the render output.