### PR TITLE
Wait and push advisories based on state

### DIFF
--- a/errata_tool/tests/cli/test_advisory_cli.py
+++ b/errata_tool/tests/cli/test_advisory_cli.py
@@ -4,10 +4,16 @@ from errata_tool.cli import main
 
 
 class FakeErratum(object):
+
+    errata_state = 'SHIPPED_LIVE'
+
     def __init__(self, **kwargs):
         pass
 
     def commit(self):
+        pass
+
+    def push(self, **kwargs):
         pass
 
 
@@ -37,6 +43,63 @@ def test_get(monkeypatch):
     monkeypatch.setattr(sys, 'argv', argv)
     monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
     main.main()
+
+
+def test_push_missing_name(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push']
+    monkeypatch.setattr(sys, 'argv', argv)
+    with pytest.raises(SystemExit):
+        main.main()
+
+
+def test_push(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push', '12345']
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
+    main.main()
+
+
+def test_push_wait_for_state(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push',
+            '--target', 'live',
+            '--wait-for-state', 'SHIPPED_LIVE',
+            '12345']
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
+    main.main()
+
+
+def test_push_when_ready(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push',
+            '--target', 'live',
+            '--push-when-ready',
+            '12345']
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
+    main.main()
+
+
+def test_wait_and_push_when_ready(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push',
+            '--target', 'live',
+            '--target', 'live',
+            '--wait-for-state', 'SHIPPED_LIVE',
+            '--push-when-ready',
+            '12345']
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
+    main.main()
+
+
+def test_push_when_ready_spurious_argument(monkeypatch):
+    argv = ['errata-tool', 'advisory', 'push',
+            '--target', 'live',
+            '--push-when-ready', 'PUSH_READY',
+            '12345']
+    monkeypatch.setattr(sys, 'argv', argv)
+    monkeypatch.setattr('errata_tool.cli.advisory.Erratum', FakeErratum)
+    with pytest.raises(SystemExit):
+        main.main()
 
 
 def test_create_missing_args(monkeypatch):


### PR DESCRIPTION
The enhancement was made in response to : https://issues.redhat.com/browse/SPMM-9887

Errata tool has a feature of blocking advisories. However, the blockers block pushing of dependent advisories which are blocked by an advisory which is not in PUSH_READY state.
Ansible automation platform requires to block operator pushes until the container images they operate on to be in SHIPPED_LIVE state. 