### PR TITLE
github: run tox tests with pyXX environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,11 @@ jobs:
         sudo apt-get install libkrb5-dev
         pip install tox
     - name: Test with tox
-      run: tox -e py -- --cov-report=xml errata_tool/tests
+      run: |
+        PY=py$(echo ${{ matrix.python-version }} | tr -d ".")
+        tox -e ${PY} -- --cov-report=xml errata_tool/tests
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
Instead of running tox with `tox -e py`, run with eg. `tox -e py27`. This matches more closely what a local user would do, and it allows us to filter dependencies in `tox.ini` according to Python versions.