### PR TITLE
README: document how to read the current list of bugs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,8 @@ Adding bugs:
 
     e.commit()
 
+    # You can read the current list of bugs with the "e.errata_bugs" property.
+
 Removing bugs:
 
 .. code-block:: python


### PR DESCRIPTION
Document the `.errata_bugs` property in the README.