### PR TITLE
release: always assign `name` from server data

### DIFF
--- a/errata_tool/release.py
+++ b/errata_tool/release.py
@@ -25,6 +25,7 @@ class Release(ErrataConnector):
         self.attributes = self.data['attributes']
         self.relationships = self.data['relationships']
         self.id = self.data['id']
+        self.name = self.attributes['name']
         self.program_manager = \
             self.relationships['program_manager']['login_name'] if \
             self.relationships.get('program_manager') else None


### PR DESCRIPTION
Prior to this change, if a user created a `Release` class by specifying an ID number instead of a `name` string, the class would always set the `name` property to `None`. For example, this would be `None`:

```python
Release(id=1234).name
```

Assign `name` when we process all the other data attributes in `_setattr()`.