### PR TITLE
Revert "Add use_quay_for_containers to ProductVersion render output"

### DIFF
--- a/errata_tool/product_version.py
+++ b/errata_tool/product_version.py
@@ -55,7 +55,6 @@ class ProductVersion(ErrataConnector):
             'rhel_release_name': rhel_release,
             'brew_tags': brew_tags,
             'is_server_only': self.is_server_only,
-            'use_quay_for_containers': self.use_quay_for_containers,
             'push_targets': [
                 str(target['name'])
                 for target in self.relationships['push_targets']

--- a/errata_tool/tests/test_product_version.py
+++ b/errata_tool/tests/test_product_version.py
@@ -39,7 +39,6 @@ def test_product_version_pretty_print(product_version):
  'push_targets': ['ftp', 'cdn_stage', 'cdn_docker_stage', 'cdn_docker', 'cdn'],
  'rhel_release_name': 'RHEL-7',
  'sig_key_name': 'redhatrelease2',
- 'use_quay_for_containers': False,
  'variants': [{'description': 'Red Hat Ceph Storage 3.1 MON',
                'enabled': True,
                'name': '7Server-RHEL-7-RHCEPH-3.1-MON',


### PR DESCRIPTION
This reverts commit d5e3fa2c746634ed32ccf7abaea8e239362f5914.

`use_quay_for_containers` does not appear to be used anymore in the Errata Tool API so we should remove it.