### PR TITLE
Add batch_id param support for create errata function

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -121,6 +121,10 @@ class Erratum(ErrataConnector):
         if 'solution' in kwargs:
             self.solution = self.fmt(kwargs['solution'])
             self._update = True
+        if 'batch_id' in kwargs:
+            self.batch_id = kwargs['batch_id']
+            self._update = True
+
 
     def __init__(self, **kwargs):
 
@@ -840,6 +844,8 @@ https://access.redhat.com/articles/11258")
             pdata['advisory[assigned_to_email]'] = self.qe_email
         if self.qe_group is not None and self.qe_group != '':
             pdata['advisory[quality_responsibility_name]'] = self.qe_group
+        if self.batch_id is not None:
+            pdata['batch[id]'] = self.batch_id
 
         if self.synopsis is None:
             raise ErrataException("Can't write erratum without synopsis")

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -31,7 +31,7 @@ class MockResponse(object):
         """Return path to our static fixture file. """
         fdir = os.path.join(FIXTURES_DIR, 'errata.devel.redhat.com/')
         filename = self._url_with_params.replace(
-            'https://errata.devel.redhat.com/', fdir)
+            'https://errata.devel.redhat.com/', fdir).replace('https://errata.stage.engineering.redhat.com/', fdir)
         # If we need to represent this API endpoint as both a directory and a
         # file, check for a ".body" file.
         if os.path.isdir(filename):


### PR DESCRIPTION
add a supported field for create errata function https://errata.devel.redhat.com/documentation/developer-guide/api-http-api.html#advisories
- batch[id]: The integer id of an existing batch