### PR TITLE
testing: don't overwrite ErrtaConnector._url

### DIFF
--- a/errata_tool/tests/cli/test_main_cli.py
+++ b/errata_tool/tests/cli/test_main_cli.py
@@ -35,6 +35,7 @@ def test_staging_connector(monkeypatch):
     argv = ['errata-tool', '--stage', 'release', 'get', 'rhceph-2.4']
     monkeypatch.setattr(sys, 'argv', argv)
     monkeypatch.setattr(errata_tool.cli.release, 'get', lambda x: None)
+    monkeypatch.setattr(ErrataConnector, '_url', 'https://fake.com')
     main.main()
     expected = 'https://errata.stage.engineering.redhat.com'
     assert ErrataConnector._url == expected


### PR DESCRIPTION
Currently testing fails for me being unable to find fixtures.  It turns out that the `--stage` test overwrites `ErrataConnector._url`, which then affects the rest of the tests.  I think this must have been working before thanks to ordering luck, which probably put the test above first, which I think will reset this to the "production" site. `monkeypatch` this so the value isn't overwritten.