### PR TITLE
connector: use persistent requests.Session

### DIFF
--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -11,7 +11,9 @@ import six
 class ErrataConnector(object):
     # Staging is https://errata.stage.engineering.redhat.com
     _url = "https://errata.devel.redhat.com"
-    _auth = HTTPSPNEGOAuth()
+    _auth = HTTPSPNEGOAuth(opportunistic_auth=True)
+    session = requests.Session()
+    session.auth = _auth
     ssl_verify = True  # Shared
     debug = False
 
@@ -99,19 +101,15 @@ class ErrataConnector(object):
         url = self.canonical_url(u)
         start = time.time()
         ret = None
+        self.session.verify = self.ssl_verify
+
         if kwargs is not None:
             if 'data' in kwargs:
-                ret = requests.post(url,
-                                    auth=self._auth,
-                                    data=kwargs['data'],
-                                    verify=self.ssl_verify)
+                ret = self.session.post(url, data=kwargs['data'])
             elif 'json' in kwargs:
-                ret = requests.post(url,
-                                    auth=self._auth,
-                                    json=kwargs['json'],
-                                    verify=self.ssl_verify)
+                ret = self.session.post(url, json=kwargs['json'])
         if ret is None:
-            ret = requests.post(url, auth=self._auth, verify=self.ssl_verify)
+            ret = self.session.post(url)
 
         self._record('POST', url, time.time() - start)
         return ret
@@ -131,29 +129,20 @@ class ErrataConnector(object):
         ret_json = None
         start = time.time()
         return_json_decoded_data = True
+        self.session.verify = self.ssl_verify
 
         if kwargs is not None:
             if 'params' in kwargs:
-                ret_data = requests.get(url,
-                                        auth=self._auth,
-                                        params=kwargs['params'],
-                                        verify=self.ssl_verify)
-            elif 'data' in kwargs:
-                ret_data = requests.get(url,
-                                        auth=self._auth,
-                                        data=kwargs['data'],
-                                        verify=self.ssl_verify)
+                ret_data = self.session.get(url, params=kwargs['params'])
+            if 'data' in kwargs:
+                ret_data = self.session.get(url, data=kwargs['data'])
             elif 'json' in kwargs:
-                ret_data = requests.get(url,
-                                        auth=self._auth,
-                                        json=kwargs['json'],
-                                        verify=self.ssl_verify)
+                ret_data = self.session.get(url, json=kwargs['json'])
             if 'raw' in kwargs:
                 return_json_decoded_data = not kwargs['raw']
 
         if ret_data is None:
-            ret_data = requests.get(url, auth=self._auth,
-                                    verify=self.ssl_verify)
+            ret_data = self.session.get(url)
 
         self._record('GET', url, time.time() - start)
 
@@ -181,20 +170,16 @@ class ErrataConnector(object):
         url = self.canonical_url(u)
         start = time.time()
         ret = None
+        self.session.verify = self.ssl_verify
+
         if kwargs is not None:
             if 'data' in kwargs:
-                ret = requests.put(url,
-                                   auth=self._auth,
-                                   data=kwargs['data'],
-                                   verify=self.ssl_verify)
+                ret = self.session.put(url, data=kwargs['data'])
             elif 'json' in kwargs:
-                ret = requests.put(url,
-                                   auth=self._auth,
-                                   json=kwargs['json'],
-                                   verify=self.ssl_verify)
+                ret = self.session.put(url, json=kwargs['json'])
 
         if ret is None:
-            ret = requests.put(url, auth=self._auth, verify=self.ssl_verify)
+            ret = self.session.put(url, auth=self._auth)
         self._record('PUT', url, time.time() - start)
         return ret
 

--- a/errata_tool/tests/cli/test_advisory_cli.py
+++ b/errata_tool/tests/cli/test_advisory_cli.py
@@ -1,6 +1,5 @@
 import sys
 import pytest
-import requests
 from errata_tool.cli import main
 from errata_tool import ErrataConnector
 
@@ -135,9 +134,8 @@ def test_create(monkeypatch):
 
 def test_add_bugs_dry_run(capsys, monkeypatch, mock_get, mock_put):
     # Mock all external calls
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
 
     # Errata ID and Bug ID are reused from some fixtures already present
     argv = ['errata-tool', '--dry-run', 'advisory',
@@ -156,11 +154,10 @@ def test_add_bugs_dry_run(capsys, monkeypatch, mock_get, mock_put):
 
 def test_add_bugs(monkeypatch, mock_get, mock_post, mock_put):
     # Mock all external calls
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
-    monkeypatch.setattr(requests, 'post', mock_post)
-    monkeypatch.setattr(requests, 'put', mock_put)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
+    monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
 
     # Errata ID and Bug ID are reused from some fixtures already present
     argv = ['errata-tool', 'advisory', 'add-bugs',

--- a/errata_tool/tests/cli/test_main_cli.py
+++ b/errata_tool/tests/cli/test_main_cli.py
@@ -35,6 +35,7 @@ def test_staging_connector(monkeypatch):
     argv = ['errata-tool', '--stage', 'release', 'get', 'rhceph-2.4']
     monkeypatch.setattr(sys, 'argv', argv)
     monkeypatch.setattr(errata_tool.cli.release, 'get', lambda x: None)
+    monkeypatch.setattr(ErrataConnector, '_url', 'https://fake.com')
     main.main()
     expected = 'https://errata.stage.engineering.redhat.com'
     assert ErrataConnector._url == expected

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -9,7 +9,6 @@ from errata_tool.product import Product
 from errata_tool.product_version import ProductVersion
 from errata_tool.release import Release
 from errata_tool.variant import Variant
-import requests
 import pytest
 from six.moves.urllib.parse import urlencode
 
@@ -92,82 +91,72 @@ def mock_put():
 
 @pytest.fixture
 def advisory(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=33840)
 
 
 @pytest.fixture
 def advisory_none_ship(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=43686)
 
 
 @pytest.fixture
 def advisory_with_batch(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=46563)
 
 
 @pytest.fixture
 def rhsa(monkeypatch, mock_get):
     """Like the advisory() fixture above, but an RHSA. """
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Erratum(errata_id=36762)
 
 
 @pytest.fixture
 def productlist(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return ProductList()
 
 
 @pytest.fixture
 def product(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Product('RHCEPH')
 
 
 @pytest.fixture
 def rhacm_product(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Product('RHACM')
 
 
 @pytest.fixture
 def product_version(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return ProductVersion('RHEL-7-RHCEPH-3.1')
 
 
 @pytest.fixture
 def release(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Release(name='rhceph-3.1')
 
 
 @pytest.fixture
 def build(monkeypatch, mock_get):
-    monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Build('ceph-12.2.5-42.el7cp')
 
 
@@ -175,7 +164,7 @@ def build(monkeypatch, mock_get):
 def rhceph_variant(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Variant(name='8Base-RHCEPH-5.0-MON')
 
 
@@ -183,7 +172,7 @@ def rhceph_variant(monkeypatch, mock_get):
 def rhacm_variant(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Variant(name='7Server-RHACM-2.0')
 
 
@@ -191,7 +180,7 @@ def rhacm_variant(monkeypatch, mock_get):
 def bug(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return Bug(1578936)
 
 
@@ -199,5 +188,5 @@ def bug(monkeypatch, mock_get):
 def jiraissue(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
-    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
     return JiraIssue("OCPBUGS-1590")

--- a/errata_tool/tests/test_add_builds.py
+++ b/errata_tool/tests/test_add_builds.py
@@ -1,17 +1,17 @@
-import requests
 import pytest
+from errata_tool import ErrataConnector
 from errata_tool import ErrataException
 
 
 class TestAddBuilds(object):
 
     def test_add_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release='RHEL-7-RHCEPH-3.1')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/add_builds'  # NOQA: E501
 
     def test_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release='RHEL-7-RHCEPH-3.1')
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -20,7 +20,7 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_no_release(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'])
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -29,14 +29,14 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_empty_no_release(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.errata_builds = {}
         with pytest.raises(ErrataException,
                            match=r'Need to specify a release'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_builds_release_none(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp'], release=None)
         expected = {
             "product_version": "RHEL-7-RHCEPH-3.1",
@@ -45,14 +45,14 @@ class TestAddBuilds(object):
         assert mock_post.kwargs['json'] == [expected]
 
     def test_builds_new_advisory(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory._new = True
         with pytest.raises(ErrataException,
                            match=r'Cannot add builds to unfiled erratum'):
             advisory.addBuilds(['ceph-1000-1.el7cp'])
 
     def test_2_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addBuilds(['ceph-1000-1.el7cp', 'foo-1.2.3-11.el7cp'])
         expected = [
             {

--- a/errata_tool/tests/test_add_cc.py
+++ b/errata_tool/tests/test_add_cc.py
@@ -1,15 +1,15 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestAddCC(object):
 
     def test_add_cc_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addCC('kdreyer@redhat.com')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/carbon_copies/add_to_cc_list'  # NOQA: E501
 
     def test_add_cc_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addCC('kdreyer@redhat.com')
         expected = {'id': 33840, 'email': 'kdreyer@redhat.com'}
         assert mock_post.kwargs['data'] == expected

--- a/errata_tool/tests/test_change_docs_reviewer.py
+++ b/errata_tool/tests/test_change_docs_reviewer.py
@@ -1,14 +1,14 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestChangeDocsReviewer(object):
 
     def test_change_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.changeDocsReviewer('kdreyer@redhat.com')
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/change_docs_reviewer'  # NOQA: E501
 
     def test_change_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.changeDocsReviewer('kdreyer@redhat.com')
         assert mock_post.kwargs['data'] == {'login_name': 'kdreyer@redhat.com'}

--- a/errata_tool/tests/test_comments.py
+++ b/errata_tool/tests/test_comments.py
@@ -1,4 +1,4 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestComments(object):
@@ -12,13 +12,13 @@ class TestComments(object):
                 {'advisory_state', 'created_at', 'errata_id', 'text', 'who'}
 
     def test_comment_argument(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addComment('test')
         expected = {'comment': 'test'}
         assert mock_post.kwargs['json'] == expected
 
     def test_comment_user(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.addComment('test')
         expected = {'user': {'id': 3002896, 'login_name': 'jdoe@redhat.com',
                              'realname': 'John Doe', 'preferences': {},
@@ -28,7 +28,7 @@ class TestComments(object):
         assert mock_post.response.json()['who'] == expected
 
     def test_comment_response(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         comment = 'test'
         advisory.addComment(comment)
         expected = {'comment': comment, 'format': 'json',

--- a/errata_tool/tests/test_external_tests.py
+++ b/errata_tool/tests/test_external_tests.py
@@ -1,14 +1,14 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestExternalTests(object):
 
     def test_external_tests_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.externalTests(test_type='rpmdiff')
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/external_tests/?filter[active]=true&filter[errata_id]=33840&filter[test_type]=rpmdiff&page[number]=2'  # NOQA: E501
 
     def test_external_tests_data(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         rpmdiff = advisory.externalTests(test_type='rpmdiff')
         assert len(rpmdiff) == 35

--- a/errata_tool/tests/test_metadata_cdn_repos.py
+++ b/errata_tool/tests/test_metadata_cdn_repos.py
@@ -1,22 +1,22 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestMetadataCdnRepos(object):
 
     def test_get_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.metadataCdnRepos()
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/metadata_cdn_repos'  # NOQA: E501
 
     def test_enable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.metadataCdnRepos(enable=[repo])
         expected = [{'enabled': True, 'repo': repo}]
         assert mock_put.kwargs['json'] == expected
 
     def test_disable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.metadataCdnRepos(disable=[repo])
         expected = [{'enabled': False, 'repo': repo}]

--- a/errata_tool/tests/test_release.py
+++ b/errata_tool/tests/test_release.py
@@ -1,6 +1,6 @@
 from datetime import date
-import requests
 from errata_tool.release import Release
+from errata_tool.connector import ErrataConnector
 
 
 class TestGet(object):
@@ -41,7 +41,7 @@ class TestGet(object):
 
 class TestAdvisories(object):
     def test_advisories(self, release, monkeypatch, mock_get):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         result = release.advisories()
         # Validate URL
         expected_url = 'https://errata.devel.redhat.com/release/860/advisories.json'  # NOQA: E501
@@ -85,15 +85,15 @@ class TestCreate(object):
     )
 
     def test_create_url(self, monkeypatch, mock_get, mock_post):
-        monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         Release.create(**self.create_kwargs)
         expected = 'https://errata.devel.redhat.com/release/create'
         assert mock_post.response.url == expected
 
     def test_create_data(self, monkeypatch, mock_get, mock_post):
-        monkeypatch.setattr(requests, 'get', mock_get)
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         Release.create(**self.create_kwargs)
         today = date.today()
         ship_date = today.strftime("%Y-%b-%d")
@@ -123,7 +123,7 @@ class TestSpecialCharacters(object):
     expected_url = 'https://errata.devel.redhat.com/api/v1/releases'
 
     def test_plus(self, monkeypatch, mock_get):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         release = Release(name='RHEL-8.4.0.Z.MAIN+EUS')
         assert release.name == 'RHEL-8.4.0.Z.MAIN+EUS'
         assert mock_get.response.url == self.expected_url
@@ -131,7 +131,7 @@ class TestSpecialCharacters(object):
             'RHEL-8.4.0.Z.MAIN+EUS'
 
     def test_plus_encoded(self, monkeypatch, mock_get, recwarn):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         release = Release(name='RHEL-8.4.0.Z.MAIN%2BEUS')
         assert release.name == 'RHEL-8.4.0.Z.MAIN+EUS'
         assert mock_get.response.url == self.expected_url

--- a/errata_tool/tests/test_reload_builds.py
+++ b/errata_tool/tests/test_reload_builds.py
@@ -1,15 +1,15 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestReloadBuilds(object):
 
     def test_reload_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.reloadBuilds()
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/reload_builds'  # NOQA: E501
 
     def test_reload_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.reloadBuilds()
         expected = {'no_rpm_listing_only': 0, 'no_current_files_only': 0}
         assert mock_post.kwargs['data'] == expected

--- a/errata_tool/tests/test_remove_builds.py
+++ b/errata_tool/tests/test_remove_builds.py
@@ -1,21 +1,21 @@
+from errata_tool import ErrataConnector
 import pytest
-import requests
 
 
 class TestRemoveBuilds(object):
 
     def test_builds_url(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/remove_build'  # NOQA: E501
 
     def test_builds_flag_set(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         assert advisory._buildschanged is True
 
     def test_builds_data(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(['ceph-12.2.5-42.el7cp'])
         expected = {
             "nvr": "ceph-12.2.5-42.el7cp",
@@ -23,7 +23,7 @@ class TestRemoveBuilds(object):
         assert mock_post.kwargs['data'] == expected
 
     def test_builds_name(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds('ceph-12.2.5-42.el7cp')
         expected = {
             "nvr": "ceph-12.2.5-42.el7cp",
@@ -31,7 +31,7 @@ class TestRemoveBuilds(object):
         assert mock_post.kwargs['data'] == expected
 
     def test_builds_tuple(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         advisory.removeBuilds(('ceph-12.2.5-42.el7cp'))
         expected = {
             "nvr": "ceph-12.2.5-42.el7cp",
@@ -39,43 +39,43 @@ class TestRemoveBuilds(object):
         assert mock_post.kwargs['data'] == expected
 
     def test_builds_none(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(None)
         assert advisory._buildschanged is False
 
     def test_builds_empty_string(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds('')
         assert advisory._buildschanged is False
 
     def test_builds_whitespace_string(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(' ')
         assert advisory._buildschanged is False
 
     def test_builds_empty_set(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(set())
         assert advisory._buildschanged is False
 
     def test_builds_empty_list(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds([])
         assert advisory._buildschanged is False
 
     def test_builds_empty_tuple(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds(())
         assert advisory._buildschanged is False
 
     def test_builds_dict(self, monkeypatch, mock_post, advisory):
-        monkeypatch.setattr(requests, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
         with pytest.raises(IndexError):
             advisory.removeBuilds({'foo': 'bar'})
         assert advisory._buildschanged is False

--- a/errata_tool/tests/test_rhsa_synopsis.py
+++ b/errata_tool/tests/test_rhsa_synopsis.py
@@ -1,12 +1,12 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestRhsaSynopsis(object):
 
     def test_synopsis(self, monkeypatch, mock_post, mock_put, rhsa):
-        """Verify that we do not include "Moderate: " prefix in PUT data."""
-        monkeypatch.setattr(requests, 'post', mock_post)
-        monkeypatch.setattr(requests, 'put', mock_put)
+        """Verify that we do not include the "Moderate: " prefix in our PUT data."""
+        monkeypatch.setattr(ErrataConnector.session, 'post', mock_post)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         # Any typical advisory update would toggle this internal "_update"
         # attribute. Simulate that here:
         rhsa._update = True

--- a/errata_tool/tests/test_text_only_repos.py
+++ b/errata_tool/tests/test_text_only_repos.py
@@ -1,22 +1,22 @@
-import requests
+from errata_tool import ErrataConnector
 
 
 class TestTextOnlyRepos(object):
 
     def test_get_url(self, monkeypatch, mock_get, advisory):
-        monkeypatch.setattr(requests, 'get', mock_get)
+        monkeypatch.setattr(ErrataConnector.session, 'get', mock_get)
         advisory.textOnlyRepos()
         assert mock_get.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/33840/text_only_repos'  # NOQA: E501
 
     def test_enable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.textOnlyRepos(enable=[repo])
         expected = [{'enabled': True, 'repo': repo}]
         assert mock_put.kwargs['json'] == expected
 
     def test_disable(self, monkeypatch, mock_put, advisory):
-        monkeypatch.setattr(requests, 'put', mock_put)
+        monkeypatch.setattr(ErrataConnector.session, 'put', mock_put)
         repo = 'rhel-7-server-rhceph-3-mon-rpms__x86_64'
         advisory.textOnlyRepos(disable=[repo])
         expected = [{'enabled': False, 'repo': repo}]


### PR DESCRIPTION
 Instead of setting up and tearing down new request sessions for every
 HTTP request, use a persistent session object in the ErrataConnector
 class.
    
 Using this with `opportunisitc_auth` set to avoid a lot of 401
 responses, an internal tool that queries builds from erratas reduced
 its runtime significantly.
 
``` 
before -> 0.84user 0.12system 1:10.05elapsed 1%CPU (0avgtext+0avgdata 51244maxresident)k
after  -> 0.32user 0.08system 0:21.05elapsed 1%CPU (0avgtext+0avgdata 51280maxresident)k
```

Unit testing and flake8 testing pass.

Depends-On: https://github.com/red-hat-storage/errata-tool/pull/251
Inspired-By: https://github.com/red-hat-storage/errata-tool/pull/146
Closes: https://github.com/red-hat-storage/errata-tool/issues/85
Closes: https://github.com/red-hat-storage/errata-tool/issues/92
    
Co-Authored-By: Ken Dreyer <kdreyer@redhat.com>
Signed-off-by: Ian Wienand <iwienand@redhat.com>
